### PR TITLE
Fix unused warnings in streaming components

### DIFF
--- a/src/handlers/hls.rs
+++ b/src/handlers/hls.rs
@@ -299,15 +299,18 @@ pub async fn get_init_segment(
         AppError::ServiceUnavailableError("HLS streaming not configured".to_string())
     })?;
 
-    let data = hls_manager.get_init_segment(camera_id).await.map_err(|_err| {
-        AppError::NotFoundError(crate::error::Resource {
-            resource_type: crate::error::ResourceType::Monitor,
-            details: vec![
-                ("camera_id".to_string(), camera_id.to_string()),
-                ("segment".to_string(), "init.mp4".to_string()),
-            ],
-        })
-    })?;
+    let data = hls_manager
+        .get_init_segment(camera_id)
+        .await
+        .map_err(|_err| {
+            AppError::NotFoundError(crate::error::Resource {
+                resource_type: crate::error::ResourceType::Monitor,
+                details: vec![
+                    ("camera_id".to_string(), camera_id.to_string()),
+                    ("segment".to_string(), "init.mp4".to_string()),
+                ],
+            })
+        })?;
 
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/src/handlers/hls.rs
+++ b/src/handlers/hls.rs
@@ -5,8 +5,8 @@
 use axum::{
     body::Body,
     extract::{Path, Query, State},
-    http::{header, HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
+    http::{header, StatusCode},
+    response::Response,
     Json,
 };
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,6 @@ use tracing::{debug, info};
 
 use crate::error::{AppError, AppResponseError, AppResult};
 use crate::server::state::AppState;
-use crate::streaming::hls::{HlsSessionManager, HlsSessionStats};
 
 /// Query parameters for LL-HLS blocking reload
 #[derive(Debug, Deserialize)]
@@ -210,7 +209,7 @@ pub async fn get_master_playlist(
     let playlist = hls_manager
         .get_master_playlist(camera_id)
         .await
-        .map_err(|e| {
+        .map_err(|_err| {
             AppError::NotFoundError(crate::error::Resource {
                 resource_type: crate::error::ResourceType::Monitor,
                 details: vec![("camera_id".to_string(), camera_id.to_string())],
@@ -260,7 +259,7 @@ pub async fn get_media_playlist(
         }
     }
 
-    let playlist = hls_manager.get_playlist(camera_id).await.map_err(|e| {
+    let playlist = hls_manager.get_playlist(camera_id).await.map_err(|_err| {
         AppError::NotFoundError(crate::error::Resource {
             resource_type: crate::error::ResourceType::Monitor,
             details: vec![("camera_id".to_string(), camera_id.to_string())],
@@ -300,7 +299,7 @@ pub async fn get_init_segment(
         AppError::ServiceUnavailableError("HLS streaming not configured".to_string())
     })?;
 
-    let data = hls_manager.get_init_segment(camera_id).await.map_err(|e| {
+    let data = hls_manager.get_init_segment(camera_id).await.map_err(|_err| {
         AppError::NotFoundError(crate::error::Resource {
             resource_type: crate::error::ResourceType::Monitor,
             details: vec![
@@ -363,7 +362,7 @@ pub async fn get_segment(
     let data = hls_manager
         .get_segment(path.camera_id, sequence)
         .await
-        .map_err(|e| {
+        .map_err(|_err| {
             AppError::NotFoundError(crate::error::Resource {
                 resource_type: crate::error::ResourceType::Monitor,
                 details: vec![

--- a/src/routes/webrtc_native.rs
+++ b/src/routes/webrtc_native.rs
@@ -22,28 +22,6 @@ use tracing::info;
 pub fn add_native_webrtc_routes(router: Router<AppState>) -> Router<AppState> {
     info!("Registering native WebRTC routes...");
 
-    let native_routes = Router::new()
-        // WebSocket signaling endpoint
-        .route(
-            "/{camera_id}/signaling",
-            get(webrtc_native::signaling_websocket),
-        )
-        // REST fallback for SDP offer
-        .route("/{camera_id}/offer", post(webrtc_native::handle_offer))
-        // ICE candidate endpoint
-        .route(
-            "/{camera_id}/{session_id}/candidate",
-            post(webrtc_native::add_ice_candidate),
-        )
-        // Close session
-        .route("/{session_id}", delete(webrtc_native::close_session))
-        // Statistics and management
-        .route("/stats", get(webrtc_native::get_stats))
-        .route("/sessions", get(webrtc_native::list_sessions))
-        .route("/sessions/{session_id}", get(webrtc_native::get_session))
-        // Health check (no auth required)
-        .route("/health", get(webrtc_native::health_check));
-
     // Apply auth middleware to all routes except health
     let authenticated_routes = Router::new()
         .route(

--- a/src/streaming/hls/session.rs
+++ b/src/streaming/hls/session.rs
@@ -7,13 +7,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, RwLock};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use super::playlist::{MediaPlaylist, PlaylistGenerator, SegmentRef};
 use super::segmenter::{FMP4Segment, HlsSegmenter, InitSegment};
-use super::storage::{HlsStorage, SegmentInfo, StorageConfig, StorageError};
+use super::storage::{HlsStorage, StorageConfig, StorageError};
 use crate::configure::streaming::HlsConfig;
-use crate::streaming::source::fifo::{FifoPacket, VideoCodec};
+use crate::streaming::source::fifo::FifoPacket;
 
 /// HLS session for a single monitor
 pub struct HlsSession {

--- a/src/streaming/source/fifo.rs
+++ b/src/streaming/source/fifo.rs
@@ -69,7 +69,6 @@ pub struct ZmFifoReader {
     video_reader: Option<BufReader<File>>,
     codec: VideoCodec,
     config: ZoneMinderConfig,
-    broadcast_capacity: usize,
     /// Broadcast channel for distributing packets to multiple consumers
     tx: broadcast::Sender<FifoPacket>,
 }
@@ -174,7 +173,6 @@ impl ZmFifoReader {
             video_reader: None,
             codec: detected_codec,
             config,
-            broadcast_capacity,
             tx,
         }
     }

--- a/src/streaming/webrtc/engine.rs
+++ b/src/streaming/webrtc/engine.rs
@@ -96,10 +96,7 @@ impl WebRtcEngine {
             ice_servers.len()
         );
 
-        Ok(Self {
-            api,
-            ice_servers,
-        })
+        Ok(Self { api, ice_servers })
     }
 
     /// Parse ICE servers from configuration

--- a/src/streaming/webrtc/engine.rs
+++ b/src/streaming/webrtc/engine.rs
@@ -21,7 +21,6 @@ use crate::configure::streaming::WebRtcConfig;
 /// WebRTC engine for creating and managing peer connections
 pub struct WebRtcEngine {
     api: API,
-    config: WebRtcConfig,
     ice_servers: Vec<RTCIceServer>,
 }
 
@@ -99,7 +98,6 @@ impl WebRtcEngine {
 
         Ok(Self {
             api,
-            config,
             ice_servers,
         })
     }


### PR DESCRIPTION
### Motivation

- Reduce compiler warning noise from unused imports, variables, and struct fields to satisfy `-D warnings` CI policy.
- Make small, targeted changes to streaming and route code without altering behavior. 
- Prepare codebase for cleaner CI runs and future refactors by removing dead fields and unused locals.

### Description

- Trimmed unused imports and adjusted error mapping closures in `src/handlers/hls.rs` to use `_err` and removed unused `HeaderMap`/`IntoResponse` imports. 
- Removed unused imports in `src/streaming/hls/session.rs` and simplified the `use` list to drop `debug`, `SegmentInfo`, and `VideoCodec` where not required. 
- Simplified native WebRTC route wiring in `src/routes/webrtc_native.rs` by removing an unused `native_routes` local variable and keeping the authenticated/public route setup. 
- Dropped unused struct fields: removed `broadcast_capacity` from `ZmFifoReader` in `src/streaming/source/fifo.rs` and removed `config` from `WebRtcEngine` in `src/streaming/webrtc/engine.rs` to silence dead field warnings.

### Testing

- Ran `cargo test --all-features`; compilation proceeded but test execution stalled and the run was interrupted before completion. 
- No unit/integration test failures were observed prior to the interruption, but the full test run did not complete.
- No `cargo fmt` or `cargo clippy` checks were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e4cf63f18832390dadc6434c488ef)