### PR TITLE
feat(zmnext): drive and ingest the per-monitor zm-next worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ APP_PROFILE=test-db cargo test --test '*' -- --include-ignored
 - **Review Fixes (2026-06)** – `docs/REVIEW_FIXES_PLAN.md` – Phased fixes from the full API review: password hashing, event-playback ACL, WebRTC startup latency (keyframe re-read, trickle ICE), HLS session lifecycle, daemon-ID unification, housekeeping.
 - **Live Audio** – `docs/AUDIO_TASKS.md` – Phases 1–3 implemented (HLS AAC mux, WebRTC G.711 pass-through + AAC→Opus); audio now arrives on the stream socket with shared-clock pts and HELLO extradata (the raw-AAC ASC-recovery stretch goal is obsolete — the socket reader ADTS-frames raw AAC from the HELLO ASC). Remaining: browser/camera verification and Phase 4 stretch (G.711→AAC for HLS, VOD audio).
 - **HEVC over WebRTC** – `docs/HEVC_WEBRTC_TASKS.md` – Phase 1 (server correctness: H.265 AU assembly, keyframe cache, RFC 7798 fmtp) implemented. Remaining: Safari verification, mobile apps; HLS remains the fallback.
+- **zm-next Worker Integration** – `docs/ZMNEXT_TASKS.md` – Drive + ingest the per-monitor `zm-core` worker over the stream socket: EVENT (0x06) parsing, Events/Frames ingest, daemon spawn/supervision, pipeline-JSON generation, per-monitor `UseZmNext` flag. Off by default; reversible per camera. Open items: the `Monitors.UseZmNext` column (ZoneMinder fork migration) and the clip storage-path contract.
 
 ## Fast Commands
 

--- a/docs/ZMNEXT_TASKS.md
+++ b/docs/ZMNEXT_TASKS.md
@@ -1,0 +1,113 @@
+# zm-next Worker Integration
+
+Status as of this branch: zm-api can drive and ingest the per-monitor `zm-next`
+worker (`zm-core`) over the existing stream-socket protocol. The feature is
+**off by default** and reversible per camera.
+
+## What landed
+
+| Task | Area | Where |
+|------|------|-------|
+| 1 | EVENT (0x06) + `Monitor` stream parsing | `src/streaming/source/protocol.rs`, `stream_socket.rs` |
+| 1 | Router → ingest sink | `src/streaming/source/router.rs` (`MonitorEventEnvelope`, `set_event_sink`) |
+| 5 | EVENT → Events/Frames ingest | `src/service/zmnext/{detail,ingest}.rs` |
+| 2 | Daemon spawns/supervises the worker | `src/daemon/manager.rs` |
+| 3 | Pipeline JSON generator | `src/service/zmnext/pipeline.rs` |
+| 4 | Per-monitor `UseZmNext` flag (graceful) | `src/repo/monitors.rs::use_zmnext` |
+| — | Config + wiring | `src/configure/zmnext.rs`, `src/server/state.rs` |
+
+## Configuration
+
+All under a new `[zmnext]` section; absent ⇒ disabled ⇒ zero behaviour change.
+
+```toml
+[zmnext]
+enabled = true                       # master switch
+
+[zmnext.worker]
+binary = "zm-core"                   # resolved under daemon.bin_path
+
+[zmnext.pipeline]
+dir = "/var/lib/zm_api/pipelines"    # generated monitor_{id}.json files
+model_path = "/var/lib/zm_api/models/yolo26n.onnx"
+detect_hw = "auto"
+detect_input_size = 640
+detect_conf_threshold = 0.35
+rtsp_transport = "tcp"
+# mqtt_url = "mqtt://localhost:1883"  # optional output_mqtt stage
+
+[zmnext.ingest]
+channel_capacity = 256
+event_name = "zm-next"
+# default_storage_id = 1             # else lowest-id storage
+idle_finalize_seconds = 0
+```
+
+The daemon controller (`[daemon].enabled`) and streaming (`[streaming].enabled`)
+must be on for the worker to be spawned and its media/events consumed.
+
+## How a monitor is routed
+
+`DaemonManager` checks, per monitor, `[zmnext].enabled && Monitors.UseZmNext`.
+When true it spawns **one** `zm-core` worker instead of `zmc`/`zma`/`zmcontrol`:
+
+```
+zm-core --monitor-id <N> --pipeline <dir>/monitor_<N>.json --socket <socks>/stream_<N>.sock
+```
+
+* Stable process-map id: `zm-core --monitor-id <N>` (paths ride as extra args).
+* Stop: SIGTERM, like every other daemon.
+* "Reload": regenerate the pipeline JSON from current DB rows, then restart
+  (zm-next has no live reload).
+* Supervision/backoff/watchdog/reconcile are the shared `ManagedProcess` paths.
+* Flipping the flag tears the other daemon down on the next `start_monitor`.
+
+## Correlation & storage contract (read before going to production)
+
+Two integration contracts are **best-effort** in this pass and need validation
+against a live zm-next:
+
+1. **Event correlation.** EVENT frames carry no event id, so ingest correlates
+   per monitor as a *session*: first `detection`/`description` opens an `Events`
+   row, detections append alarm `Frames` + bump scores, `recording_saved`
+   finalizes it (file name, duration, end time) and closes the session. One open
+   event per monitor at a time. If zm-next can run overlapping events per
+   monitor, this needs revisiting.
+
+2. **Clip path.** `Events.DefaultVideo` stores only the file name; ZoneMinder
+   derives the full path from `Storage.Path` + `Scheme` + event id. zm-next's
+   `store_event` therefore **must** write its clip where ZM expects it, or
+   playback won't resolve. The generator points `store_event.root` at the
+   monitor's storage path; the per-event subdirectory layout (event id is
+   assigned by zm-api on the opening detection, not known at pipeline-generation
+   time) is the open item to nail down with the fork owner — options: zm-next
+   names by timestamp and zm-api stores an absolute path (needs a schema/path
+   column), or zm-api moves the clip into the scheme location on
+   `recording_saved`. The reported absolute path is currently logged.
+
+## Open coordination items (ZoneMinder fork)
+
+* **`Monitors.UseZmNext TINYINT NOT NULL DEFAULT 0`** — owned by the fork's
+  migrations. Until it ships, `repo::monitors::use_zmnext` degrades to `false`
+  (legacy) on the missing column, so this code is inert and safe. It activates
+  automatically once the column exists. **Do not** add `UseZmNext` to the
+  `monitors` SeaORM entity — that widens the base `SELECT` and breaks every
+  monitor query on pre-migration databases.
+* The clip-path contract above.
+
+## Per-camera migration (Task 6)
+
+The flag makes every step reversible:
+
+1. `UPDATE Monitors SET UseZmNext=1 WHERE Id=<N>;`
+2. Reconcile (≤60 s) or `restart_monitor(<N>)`: zm-api stops legacy zmc/zma and
+   spawns the zm-next worker, which opens its **own** RTSP connection (no shared
+   `/dev/shm`, no DB writes from zm-next — a clean parallel run).
+3. Validate parity vs. the same camera on legacy: motion/detection, recording
+   continuity, live latency (WebRTC/HLS pull from the worker's stream socket
+   exactly as from zmc).
+4. Happy ⇒ leave it. Unhappy ⇒ `UPDATE Monitors SET UseZmNext=0` and reconcile;
+   the worker is torn down and zmc/zma resume.
+
+PTZ and two-way audio for zm-next monitors go through zm-api's ONVIF client
+straight to the camera, **not** the stream socket.

--- a/docs/ZMNEXT_TASKS.md
+++ b/docs/ZMNEXT_TASKS.md
@@ -62,30 +62,38 @@ zm-core --monitor-id <N> --pipeline <dir>/monitor_<N>.json --socket <socks>/stre
 * Supervision/backoff/watchdog/reconcile are the shared `ManagedProcess` paths.
 * Flipping the flag tears the other daemon down on the next `start_monitor`.
 
-## Correlation & storage contract (read before going to production)
+## Event-id assignment handshake (correlation + clip path)
 
-Two integration contracts are **best-effort** in this pass and need validation
-against a live zm-next:
+The event id is owned by zm-api end to end and handed to `store_event` at
+clip-open, so clips land natively in ZoneMinder's tree — no schema change, no
+file relocation. The contract `store_event` (zm-next) must implement:
 
-1. **Event correlation.** EVENT frames carry no event id, so ingest correlates
-   per monitor as a *session*: first `detection`/`description` opens an `Events`
-   row, detections append alarm `Frames` + bump scores, `recording_saved`
-   finalizes it (file name, duration, end time) and closes the session. One open
-   event per monitor at a time. If zm-next can run overlapping events per
-   monitor, this needs revisiting.
+1. **Open** — when `store_event` begins a segment it emits an EVENT (0x06), code
+   **`0x0304 recording_opening`** on the Monitor stream, with `wall_clock_us` =
+   start and `json_detail`:
+   ```json
+   { "clip_token": "<opaque store_event handle>", "trigger": "detection" }
+   ```
+2. **Assign** — zm-api allocates (or adopts) the `Events` row, computes the
+   Medium-scheme location `{Storage.Path}/{monitor}/{YYYY-MM-DD}/{event_id}` +
+   `{event_id}-video.mp4`, sets `Scheme=Medium`/`DefaultVideo`, and replies with
+   a **`0x11 Command`** (JSON) on the same connection:
+   ```json
+   { "cmd": "assign_recording", "clip_token": "<echoed>",
+     "event_id": 512, "dir": ".../3/2026-06-22/512", "video_name": "512-video.mp4" }
+   ```
+   `store_event` **stages then renames**: record to a temp file immediately, then
+   move to `dir/video_name` once the assignment arrives (before emitting
+   `recording_saved`) — never blocks capture, tolerates reply latency.
+3. **Save** — on close, `recording_saved` (0x0303) echoes **`"event_id": 512`**
+   in its `json_detail` so zm-api finalizes the exact row (duration, end time).
 
-2. **Clip path.** `Events.DefaultVideo` stores only the file name; ZoneMinder
-   derives the full path from `Storage.Path` + `Scheme` + event id. zm-next's
-   `store_event` therefore **must** write its clip where ZM expects it, or
-   playback won't resolve. The generator points `store_event.root` at the
-   monitor's storage path; the per-event subdirectory layout (event id is
-   assigned by zm-api on the opening detection, not known at pipeline-generation
-   time) is the open item to nail down with the fork owner — options: zm-next
-   names by timestamp and zm-api stores an absolute path (needs a schema/path
-   column), or zm-api moves the clip into the scheme location on
-   `recording_saved`. The reported absolute path is currently logged.
+ZoneMinder's playback then derives the same path; the clip is fully native.
+One event is open per monitor at a time; `detection`/`description` decorate the
+open row (and open one themselves if they arrive before `recording_opening`,
+which then adopts it).
 
-## Open coordination items (ZoneMinder fork)
+## Open coordination items (ZoneMinder fork / zm-next)
 
 * **`Monitors.UseZmNext TINYINT NOT NULL DEFAULT 0`** — owned by the fork's
   migrations. Until it ships, `repo::monitors::use_zmnext` degrades to `false`
@@ -93,7 +101,9 @@ against a live zm-next:
   automatically once the column exists. **Do not** add `UseZmNext` to the
   `monitors` SeaORM entity — that widens the base `SELECT` and breaks every
   monitor query on pre-migration databases.
-* The clip-path contract above.
+* **`store_event` handshake (above)** — emit `recording_opening`, consume
+  `assign_recording` (stage-then-rename), and echo `event_id` in
+  `recording_saved`. This is the one zm-next change the integration requires.
 
 ## Per-camera migration (Task 6)
 

--- a/docs/ZMNEXT_TASKS.md
+++ b/docs/ZMNEXT_TASKS.md
@@ -62,31 +62,67 @@ zm-core --monitor-id <N> --pipeline <dir>/monitor_<N>.json --socket <socks>/stre
 * Supervision/backoff/watchdog/reconcile are the shared `ManagedProcess` paths.
 * Flipping the flag tears the other daemon down on the next `start_monitor`.
 
+## Recorder pipeline (merged `store` plugin)
+
+zm-next folded `store_filesystem` + `store_event` into one `store` plugin with a
+`mode`. The generator emits a single `store` stage and maps the monitor's
+ZoneMinder function to the mode:
+
+| ZM function | `store.mode` |
+|-------------|--------------|
+| `Record` | `continuous` |
+| `Mocord` | `both` |
+| `Modect`, `Nodect` | `event` |
+| `Monitor`/`None` | `continuous` (default) |
+
+`continuous`/`both` emit `max_secs`; `event`/`both` emit `pre_roll_sec`,
+`post_roll_sec`, `max_buffer_sec`, `trigger_types` (all tunable in
+`[zmnext.pipeline]`). Every segment (continuous) and every clip (event) is one
+ZM event and runs the handshake below.
+
+> **Same-filesystem requirement:** the `store` `root` and the `dir` zm-api hands
+> back in `assign_recording` must be on the **same mount** — the worker renames
+> the in-progress file into `dir` with an open fd, and a cross-fs target fails
+> (the clip then keeps the worker's own name). The generator points `store.root`
+> at the monitor's storage path, which is also what zm-api derives `dir` from, so
+> they align by construction as long as the storage tree is one filesystem.
+
 ## Event-id assignment handshake (correlation + clip path)
 
-The event id is owned by zm-api end to end and handed to `store_event` at
+The event id is owned by zm-api end to end and handed to the `store` plugin at
 clip-open, so clips land natively in ZoneMinder's tree — no schema change, no
-file relocation. The contract `store_event` (zm-next) must implement:
+file relocation. The contract zm-next must implement:
 
-1. **Open** — when `store_event` begins a segment it emits an EVENT (0x06), code
-   **`0x0304 recording_opening`** on the Monitor stream, with `wall_clock_us` =
-   start and `json_detail`:
+1. **Open** — when the `store` plugin begins a segment it emits an EVENT (0x06),
+   code **`0x0304 recording_opening`** on the Monitor stream, with
+   `wall_clock_us` = start and `json_detail`:
    ```json
-   { "clip_token": "<opaque store_event handle>", "trigger": "detection" }
+   { "event": "RecordingOpening", "clip_token": "<opaque handle>", "trigger": "continuous" }
    ```
-2. **Assign** — zm-api allocates (or adopts) the `Events` row, computes the
-   Medium-scheme location `{Storage.Path}/{monitor}/{YYYY-MM-DD}/{event_id}` +
-   `{event_id}-video.mp4`, sets `Scheme=Medium`/`DefaultVideo`, and replies with
-   a **`0x11 Command`** (JSON) on the same connection:
+   `trigger` is `"continuous"` for a continuous segment, else the trigger type
+   (`"detection"`, `"motion"`, `"audio_event"`, `"tracked_detection"`, …); zm-api
+   maps it to the event `Cause`.
+2. **Assign** — zm-api allocates (or adopts) the `Events` row, sets `Cause` from
+   `trigger`, computes the Medium-scheme location
+   `{Storage.Path}/{monitor}/{YYYY-MM-DD}/{event_id}` + `{event_id}-video.mp4`,
+   sets `Scheme=Medium`/`DefaultVideo`, and replies (fire-and-forget) with a
+   **`0x11 Command`** (JSON) on the same connection:
    ```json
-   { "cmd": "assign_recording", "clip_token": "<echoed>",
+   { "cmd": "assign_recording", "clip_token": "<echoed verbatim>",
      "event_id": 512, "dir": ".../3/2026-06-22/512", "video_name": "512-video.mp4" }
    ```
-   `store_event` **stages then renames**: record to a temp file immediately, then
+   The worker **stages then renames**: record to a temp file immediately, then
    move to `dir/video_name` once the assignment arrives (before emitting
    `recording_saved`) — never blocks capture, tolerates reply latency.
-3. **Save** — on close, `recording_saved` (0x0303) echoes **`"event_id": 512`**
-   in its `json_detail` so zm-api finalizes the exact row (duration, end time).
+3. **Save** — on close, `recording_saved` (0x0303) `json_detail`:
+   ```json
+   { "event": "EventClip", "event_id": 512, "path": "<final path>",
+     "cause": "<cause>", "duration": 12.5, "frames": 300 }
+   ```
+   `duration` is **seconds**. zm-api finalizes the row by `event_id` (end time,
+   frames, duration, stored video name). `event_id` is `0` (or absent) if the
+   clip closed before the assignment arrived — zm-api then falls back to the open
+   session, or creates a row from the clip.
 
 ZoneMinder's playback then derives the same path; the clip is fully native.
 One event is open per monitor at a time; `detection`/`description` decorate the
@@ -101,9 +137,10 @@ which then adopts it).
   automatically once the column exists. **Do not** add `UseZmNext` to the
   `monitors` SeaORM entity — that widens the base `SELECT` and breaks every
   monitor query on pre-migration databases.
-* **`store_event` handshake (above)** — emit `recording_opening`, consume
-  `assign_recording` (stage-then-rename), and echo `event_id` in
-  `recording_saved`. This is the one zm-next change the integration requires.
+* **`store` plugin handshake (above)** — emit `recording_opening`, consume
+  `assign_recording` (stage-then-rename, same-filesystem `dir`), and echo
+  `event_id` in `recording_saved`. This is the one zm-next change the
+  integration requires.
 
 ## Per-camera migration (Task 6)
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -8,7 +8,7 @@ use crate::util::dir::get_project_root;
 
 use self::{
     daemon::DaemonConfig, db::DatabaseConfig, http::HttpClientConfig, secret::SecretConfig,
-    sentry::SentryConfig, server::ServerConfig, streaming::StreamingConfig,
+    sentry::SentryConfig, server::ServerConfig, streaming::StreamingConfig, zmnext::ZmNextConfig,
 };
 
 pub mod daemon;
@@ -21,6 +21,7 @@ pub mod server;
 pub mod streaming;
 pub mod tracing;
 pub mod zmconf;
+pub mod zmnext;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AppConfig {
@@ -33,6 +34,10 @@ pub struct AppConfig {
     pub streaming: StreamingConfig,
     #[serde(default)]
     pub daemon: DaemonConfig,
+    /// zm-next worker integration (spawn + pipeline + ingest). Defaults to a
+    /// disabled, zero-impact configuration when the `[zmnext]` block is absent.
+    #[serde(default)]
+    pub zmnext: ZmNextConfig,
 }
 
 impl AppConfig {

--- a/src/configure/zmnext.rs
+++ b/src/configure/zmnext.rs
@@ -1,0 +1,121 @@
+//! Configuration for the zm-next worker integration.
+//!
+//! Covers the three zm-api-side concerns of driving a zm-next worker:
+//!   * spawning the worker binary (`[zmnext.worker]`),
+//!   * generating its pipeline JSON from the Monitors/Zones rows
+//!     (`[zmnext.pipeline]`),
+//!   * ingesting the analysis EVENTs it emits back into Events/Frames
+//!     (`[zmnext.ingest]`).
+//!
+//! The whole section defaults to a disabled, zero-impact configuration: with no
+//! `[zmnext]` block, `enabled` is false and the daemon keeps spawning legacy
+//! `zmc`/`zma` exactly as before.
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ZmNextConfig {
+    /// Master switch. When false, no monitor is routed to a zm-next worker
+    /// regardless of its per-monitor flag, and the ingest task is not spawned.
+    pub enabled: bool,
+    pub worker: WorkerConfig,
+    pub pipeline: PipelineConfig,
+    pub ingest: IngestConfig,
+}
+
+/// How to spawn and supervise the per-monitor zm-next worker process.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct WorkerConfig {
+    /// Worker executable. Resolved on `PATH` when not absolute.
+    pub binary: String,
+}
+
+/// Inputs to the pipeline-JSON generator.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct PipelineConfig {
+    /// Directory the generated `monitor_{id}.json` pipeline files are written
+    /// to (and passed to the worker via `--pipeline`).
+    pub dir: PathBuf,
+    /// Detection model the generated `decode_detect` stage points at.
+    pub model_path: PathBuf,
+    /// Hardware selector for the detect stage ("auto"/"cpu"/"cuda"/"metal").
+    pub detect_hw: String,
+    /// Square detector input size in pixels.
+    pub detect_input_size: u32,
+    /// Default detector confidence threshold (0.0–1.0).
+    pub detect_conf_threshold: f32,
+    /// RTSP transport for the capture stage ("tcp"/"udp").
+    pub rtsp_transport: String,
+    /// Optional MQTT broker URL; when set, an `output_mqtt` stage is appended.
+    pub mqtt_url: Option<String>,
+}
+
+/// How decoded EVENTs are mapped onto Events/Frames rows.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct IngestConfig {
+    /// Bounded queue between the socket readers and the ingest task. Events are
+    /// dropped (with a warning) rather than stalling media when this fills.
+    pub channel_capacity: usize,
+    /// Name stamped on Events rows created from zm-next activity.
+    pub event_name: String,
+    /// Storage row id the indexed clips belong to. `None` → ZoneMinder's
+    /// default (lowest-id) storage, resolved at ingest time.
+    pub default_storage_id: Option<u16>,
+    /// Idle gap (seconds) after which an open event with no further detections
+    /// is auto-finalized if no `recording_saved` arrived. 0 disables.
+    pub idle_finalize_seconds: u64,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            binary: "zm-core".to_string(),
+        }
+    }
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            dir: PathBuf::from("/var/lib/zm_api/pipelines"),
+            model_path: PathBuf::from("/var/lib/zm_api/models/yolo26n.onnx"),
+            detect_hw: "auto".to_string(),
+            detect_input_size: 640,
+            detect_conf_threshold: 0.35,
+            rtsp_transport: "tcp".to_string(),
+            mqtt_url: None,
+        }
+    }
+}
+
+impl Default for IngestConfig {
+    fn default() -> Self {
+        Self {
+            channel_capacity: 256,
+            event_name: "zm-next".to_string(),
+            default_storage_id: None,
+            idle_finalize_seconds: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_disabled_and_safe() {
+        let cfg = ZmNextConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.worker.binary, "zm-core");
+        assert_eq!(cfg.ingest.channel_capacity, 256);
+        assert_eq!(cfg.ingest.default_storage_id, None);
+        assert_eq!(cfg.pipeline.detect_input_size, 640);
+        assert!(cfg.pipeline.mqtt_url.is_none());
+    }
+}

--- a/src/configure/zmnext.rs
+++ b/src/configure/zmnext.rs
@@ -52,6 +52,15 @@ pub struct PipelineConfig {
     pub rtsp_transport: String,
     /// Optional MQTT broker URL; when set, an `output_mqtt` stage is appended.
     pub mqtt_url: Option<String>,
+    /// Continuous-segment rotation length, seconds (`store` `max_secs`).
+    pub segment_max_secs: u64,
+    /// Event-clip pre/post-roll, seconds (`store` `pre_roll_sec`/`post_roll_sec`).
+    pub pre_roll_sec: u64,
+    pub post_roll_sec: u64,
+    /// Event-clip ring-buffer bound, seconds (`store` `max_buffer_sec`).
+    pub max_buffer_sec: u64,
+    /// Trigger types the event recorder records on (`store` `trigger_types`).
+    pub trigger_types: Vec<String>,
 }
 
 /// How decoded EVENTs are mapped onto Events/Frames rows.
@@ -89,6 +98,16 @@ impl Default for PipelineConfig {
             detect_conf_threshold: 0.35,
             rtsp_transport: "tcp".to_string(),
             mqtt_url: None,
+            segment_max_secs: 300,
+            pre_roll_sec: 5,
+            post_roll_sec: 10,
+            max_buffer_sec: 15,
+            trigger_types: vec![
+                "detection".to_string(),
+                "motion".to_string(),
+                "audio_event".to_string(),
+                "tracked_detection".to_string(),
+            ],
         }
     }
 }

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -1754,12 +1754,14 @@ impl DaemonManager {
         let zone_specs = pipeline::zone_specs_from_models(&zones);
         let events_root = self.zmnext_events_root(monitor).await;
         let source_url = monitor.path.clone().unwrap_or_default();
+        let mode = pipeline::StoreMode::from_function(&monitor.function);
 
         let value = pipeline::generate_pipeline(
             monitor_id,
             &source_url,
             &zone_specs,
             &rt.config.pipeline,
+            mode,
             &events_root,
         );
         pipeline::write_pipeline_file(&rt.config.pipeline.dir, monitor_id, &value).map_err(|e| {
@@ -1769,7 +1771,7 @@ impl DaemonManager {
         })
     }
 
-    /// Resolve the directory the worker's `store_event` stage writes clips to:
+    /// Resolve the directory the worker's `store` plugin writes clips to:
     /// the monitor's storage path, else the default (lowest-id) storage, else a
     /// conventional fallback.
     async fn zmnext_events_root(&self, monitor: &monitors::Model) -> PathBuf {

--- a/src/daemon/manager.rs
+++ b/src/daemon/manager.rs
@@ -5,23 +5,37 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use std::path::PathBuf;
+
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder,
 };
 use tokio::process::Command;
 use tokio::sync::{mpsc, Notify, RwLock};
 use tracing::{debug, error, info, warn};
 
+use crate::configure::zmnext::ZmNextConfig;
 use crate::daemon::config::DaemonConfig;
 use crate::daemon::daemons::DaemonDefinition;
 use crate::daemon::ipc::{DaemonResponse, ProcessStatus, SystemStats, SystemStatus};
 use crate::daemon::process::{ManagedProcess, ProcessState};
 use crate::daemon::stats;
 use crate::entity::sea_orm_active_enums::{Capturing, Function, MonitorType, Status};
-use crate::entity::{filters, monitors, servers};
+use crate::entity::{filters, monitors, servers, storage, zones};
 use crate::error::AppResult;
+use crate::service::zmnext::pipeline;
+
+/// Runtime context the manager needs to drive zm-next workers: the validated
+/// config plus the stream-socket directory (from the streaming config) used to
+/// build each worker's `--socket` path.
+#[derive(Debug, Clone)]
+struct ZmNextRuntime {
+    config: ZmNextConfig,
+    socks_path: String,
+}
 
 /// Internal command for the daemon manager.
 #[derive(Debug)]
@@ -62,6 +76,9 @@ pub struct DaemonManager {
     running: Arc<RwLock<bool>>,
     /// Database connection for querying monitors
     db: Option<Arc<DatabaseConnection>>,
+    /// zm-next worker runtime; `None` (the default) means every monitor stays
+    /// on legacy zmc/zma regardless of any per-monitor flag.
+    zmnext: Option<Arc<ZmNextRuntime>>,
 }
 
 impl DaemonManager {
@@ -76,12 +93,23 @@ impl DaemonManager {
             server_id,
             running: Arc::new(RwLock::new(false)),
             db: None,
+            zmnext: None,
         }
     }
 
     /// Set the database connection for querying monitors.
     pub fn set_database(&mut self, db: Arc<DatabaseConnection>) {
         self.db = Some(db);
+    }
+
+    /// Enable zm-next worker control. Call before `startup()` when
+    /// `[zmnext].enabled` is set; `socks_path` is the streaming stream-socket
+    /// directory used to build each worker's `--socket` path. A disabled config
+    /// is ignored, keeping every monitor on legacy zmc/zma.
+    pub fn set_zmnext(&mut self, config: ZmNextConfig, socks_path: String) {
+        if config.enabled {
+            self.zmnext = Some(Arc::new(ZmNextRuntime { config, socks_path }));
+        }
     }
 
     /// Create a new daemon manager with database connection.
@@ -99,6 +127,7 @@ impl DaemonManager {
             server_id,
             running: Arc::new(RwLock::new(false)),
             db: Some(db),
+            zmnext: None,
         }
     }
 
@@ -483,6 +512,31 @@ impl DaemonManager {
 
     /// Send SIGHUP to reload daemon configuration.
     pub async fn reload_daemon(&self, id: &str) -> AppResult<DaemonResponse> {
+        // zm-next has no live config reload: "reload" means regenerate the
+        // pipeline JSON from the current DB rows and restart the worker so it
+        // re-reads the file. SIGHUP would be a no-op for it.
+        if let Some(monitor_id) = zmnext_monitor_id_from_id(id) {
+            let Some(rt) = self.zmnext.clone() else {
+                return Ok(DaemonResponse::error("zm-next is not configured"));
+            };
+            let monitor = match &self.db {
+                Some(db) => {
+                    monitors::Entity::find_by_id(monitor_id)
+                        .one(db.as_ref())
+                        .await?
+                }
+                None => None,
+            };
+            let Some(monitor) = monitor else {
+                return Ok(DaemonResponse::error(format!(
+                    "Monitor {monitor_id} not found for zm-next reload"
+                )));
+            };
+            self.write_zmnext_pipeline(&monitor, &rt).await?;
+            info!("Regenerated zm-next pipeline for monitor {monitor_id}, restarting worker");
+            return self.restart_daemon(id, &[]).await;
+        }
+
         let processes = self.processes.read().await;
 
         let process = match processes.get(id) {
@@ -809,6 +863,37 @@ impl DaemonManager {
             let monitor_id = monitor.id;
             let function = &monitor.function;
             let monitor_type = &monitor.r#type;
+
+            // zm-next monitors run a single self-contained worker (capture +
+            // analysis + record) instead of zmc/zma/zmcontrol. PTZ for these is
+            // handled out-of-band via zm-api's ONVIF client, not a daemon.
+            if self.use_zmnext(monitor_id).await {
+                match self.start_zmnext_worker(monitor).await {
+                    Ok(resp) if resp.success => {
+                        started += 1;
+                        info!("Started zm-next worker for monitor {}", monitor_id);
+                    }
+                    Ok(resp) => {
+                        if !resp.message.contains("already running") {
+                            failed += 1;
+                            errors.push(format!("zm-core[{}]: {}", monitor_id, resp.message));
+                            warn!(
+                                "Failed to start zm-next worker for monitor {}: {}",
+                                monitor_id, resp.message
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        errors.push(format!("zm-core[{}]: {}", monitor_id, e));
+                        error!(
+                            "Error starting zm-next worker for monitor {}: {}",
+                            monitor_id, e
+                        );
+                    }
+                }
+                continue;
+            }
 
             // Determine if we need analysis daemon (motion detection)
             let needs_analysis = matches!(function, Function::Modect | Function::Mocord);
@@ -1607,6 +1692,114 @@ impl DaemonManager {
         format!("zmc -m {}", monitor_id)
     }
 
+    /// Whether this monitor should run on a zm-next worker instead of legacy
+    /// zmc/zma: requires zm-next to be enabled in config AND the per-monitor
+    /// `UseZmNext` flag to be set. The flag read is isolated so the column's
+    /// absence (the ZoneMinder fork has not added it yet) degrades to `false`.
+    async fn use_zmnext(&self, monitor_id: u32) -> bool {
+        if self.zmnext.is_none() {
+            return false;
+        }
+        match &self.db {
+            Some(db) => crate::repo::monitors::use_zmnext(db.as_ref(), monitor_id).await,
+            None => false,
+        }
+    }
+
+    /// Generate the monitor's pipeline JSON and (re)start its `zm-core` worker.
+    /// The worker is keyed by the stable id `zm-core --monitor-id N`; the
+    /// generated `--pipeline`/`--socket` paths ride as extra args so stop and
+    /// restart can re-derive the id without recomputing them.
+    async fn start_zmnext_worker(&self, monitor: &monitors::Model) -> AppResult<DaemonResponse> {
+        let Some(rt) = self.zmnext.clone() else {
+            return Ok(DaemonResponse::error("zm-next is not configured"));
+        };
+        let monitor_id = monitor.id;
+
+        let pipeline_path = self.write_zmnext_pipeline(monitor, &rt).await?;
+        let socket_path = format!(
+            "{}/stream_{}.sock",
+            rt.socks_path.trim_end_matches('/'),
+            monitor_id
+        );
+        let id = zmnext_daemon_id(monitor_id);
+        let extra = vec![
+            "--pipeline".to_string(),
+            pipeline_path.to_string_lossy().into_owned(),
+            "--socket".to_string(),
+            socket_path,
+        ];
+        self.start_daemon(&id, &extra).await
+    }
+
+    /// (Re)generate the monitor's pipeline JSON from its current Monitors/Zones
+    /// rows and write it to the configured pipeline directory, returning the
+    /// file path. This is the unit of "reload" for zm-next — the worker has no
+    /// live config reload, so a restart re-reads the regenerated file.
+    async fn write_zmnext_pipeline(
+        &self,
+        monitor: &monitors::Model,
+        rt: &ZmNextRuntime,
+    ) -> AppResult<PathBuf> {
+        let monitor_id = monitor.id;
+        let zones = match &self.db {
+            Some(db) => {
+                zones::Entity::find()
+                    .filter(zones::Column::MonitorId.eq(monitor_id))
+                    .all(db.as_ref())
+                    .await?
+            }
+            None => Vec::new(),
+        };
+        let zone_specs = pipeline::zone_specs_from_models(&zones);
+        let events_root = self.zmnext_events_root(monitor).await;
+        let source_url = monitor.path.clone().unwrap_or_default();
+
+        let value = pipeline::generate_pipeline(
+            monitor_id,
+            &source_url,
+            &zone_specs,
+            &rt.config.pipeline,
+            &events_root,
+        );
+        pipeline::write_pipeline_file(&rt.config.pipeline.dir, monitor_id, &value).map_err(|e| {
+            crate::error::AppError::InternalServerError(format!(
+                "Failed to write zm-next pipeline for monitor {monitor_id}: {e}"
+            ))
+        })
+    }
+
+    /// Resolve the directory the worker's `store_event` stage writes clips to:
+    /// the monitor's storage path, else the default (lowest-id) storage, else a
+    /// conventional fallback.
+    async fn zmnext_events_root(&self, monitor: &monitors::Model) -> PathBuf {
+        if let Some(db) = &self.db {
+            let by_id = match monitor.storage_id {
+                Some(sid) if sid != 0 => storage::Entity::find_by_id(sid)
+                    .one(db.as_ref())
+                    .await
+                    .ok()
+                    .flatten(),
+                _ => None,
+            };
+            let resolved = match by_id {
+                Some(s) => Some(s),
+                None => storage::Entity::find()
+                    .order_by_asc(storage::Column::Id)
+                    .one(db.as_ref())
+                    .await
+                    .ok()
+                    .flatten(),
+            };
+            if let Some(s) = resolved {
+                if !s.path.is_empty() {
+                    return PathBuf::from(s.path);
+                }
+            }
+        }
+        PathBuf::from("/var/lib/zm/events")
+    }
+
     pub async fn start_monitor(&self, monitor_id: u32) -> AppResult<DaemonResponse> {
         let db = match &self.db {
             Some(db) => db.clone(),
@@ -1628,8 +1821,24 @@ impl DaemonManager {
                 })
             })?;
 
+        // zm-next monitors run a single worker instead of zmc/zma. Tear down
+        // any legacy daemons first so flipping the flag swaps cleanly.
+        if self.use_zmnext(monitor_id).await {
+            let _ = self
+                .stop_daemon(&zmc_daemon_id(&monitor.r#type, &monitor.device, monitor_id))
+                .await;
+            let _ = self.stop_daemon(&format!("zma -m {}", monitor_id)).await;
+            return self.start_zmnext_worker(&monitor).await;
+        }
+
         let mut started = Vec::new();
         let mut errors = Vec::new();
+
+        // Not a zm-next monitor: tear down any stale worker before starting the
+        // legacy daemons (handles flipping the flag back off).
+        if self.zmnext.is_some() {
+            let _ = self.stop_daemon(&zmnext_daemon_id(monitor_id)).await;
+        }
 
         // Start zmc (capture daemon). Use the shared id derivation so Local
         // monitors get the same `-d <device>` key that stop/status expect.
@@ -1734,6 +1943,23 @@ impl DaemonManager {
             }
         }
 
+        // Stop any zm-next worker (no-op when the monitor is on legacy capture).
+        if self.zmnext.is_some() {
+            match self.stop_daemon(&zmnext_daemon_id(monitor_id)).await {
+                Ok(resp) if resp.success => {
+                    stopped.push("zm-core".to_string());
+                    info!("Stopped zm-next worker for monitor {}", monitor_id);
+                }
+                Ok(resp) => {
+                    if !resp.message.contains("not found") && !resp.message.contains("not running")
+                    {
+                        errors.push(format!("zm-core: {}", resp.message));
+                    }
+                }
+                Err(e) => errors.push(format!("zm-core: {}", e)),
+            }
+        }
+
         if errors.is_empty() {
             Ok(DaemonResponse::ok(format!(
                 "Stopped monitor {}: {}",
@@ -1777,16 +2003,22 @@ impl DaemonManager {
 
     /// Check if a specific monitor's daemons are running.
     ///
-    /// Returns true if at least zmc is running for the monitor.
+    /// Returns true if the monitor's primary capture daemon is running — the
+    /// `zm-core` worker for a zm-next monitor, otherwise `zmc`. Keying off the
+    /// flag-appropriate daemon lets reconciliation swap them when the flag
+    /// flips: the now-correct daemon reads as "not running", so `start_monitor`
+    /// fires and tears down the other.
     pub async fn is_monitor_running(&self, monitor_id: u32) -> bool {
-        let zmc_id = self.zmc_id_for_monitor(monitor_id).await;
-        let processes = self.processes.read().await;
-
-        if let Some(process) = processes.get(&zmc_id) {
-            process.is_running()
+        let id = if self.use_zmnext(monitor_id).await {
+            zmnext_daemon_id(monitor_id)
         } else {
-            false
-        }
+            self.zmc_id_for_monitor(monitor_id).await
+        };
+        let processes = self.processes.read().await;
+        processes
+            .get(&id)
+            .map(|process| process.is_running())
+            .unwrap_or(false)
     }
 
     /// Get status of a specific monitor's daemons.
@@ -1887,9 +2119,38 @@ fn validate_daemon_spec(command: &str, args: &[String]) -> Result<(), String> {
             [m, id] if m == "-m" && int_arg(id) => Ok(()),
             _ => Err(format!("zmtrack.pl args invalid: {:?}", args)),
         },
+        // zm-next worker: `--monitor-id <int> --pipeline <abs path> --socket
+        // <abs path>` in any order. zm-api generates these paths itself; the
+        // validator still enforces them as absolute and traversal-free so a
+        // forwarded IPC/HTTP request can't smuggle arbitrary args.
+        "zm-core" => validate_zmnext_args(args),
         _ => Err(format!("unknown daemon: {:?}", command)),
     };
     result
+}
+
+/// Validate the `zm-core` worker arg list (order-independent). Requires exactly
+/// `--monitor-id`, `--pipeline` and `--socket`, each with a valid value.
+fn validate_zmnext_args(args: &[String]) -> Result<(), String> {
+    let safe_path = |p: &str| p.starts_with('/') && !p.contains("..");
+    let (mut have_monitor, mut have_pipeline, mut have_socket) = (false, false, false);
+    let mut chunks = args.chunks_exact(2);
+    for pair in chunks.by_ref() {
+        match (pair[0].as_str(), pair[1].as_str()) {
+            ("--monitor-id", v) if v.parse::<u32>().is_ok() => have_monitor = true,
+            ("--pipeline", v) if safe_path(v) => have_pipeline = true,
+            ("--socket", v) if safe_path(v) => have_socket = true,
+            _ => return Err(format!("zm-core args invalid: {:?}", args)),
+        }
+    }
+    if !chunks.remainder().is_empty() {
+        return Err(format!("zm-core args must be flag/value pairs: {:?}", args));
+    }
+    if have_monitor && have_pipeline && have_socket {
+        Ok(())
+    } else {
+        Err(format!("zm-core missing required args: {:?}", args))
+    }
 }
 
 /// Compute the "extras" — args present on a `ManagedProcess` that are NOT
@@ -1992,13 +2253,31 @@ struct StartupGates {
 fn extract_monitor_id(args: &[String]) -> Option<u32> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
-        if arg == "-m" {
+        // `-m N` (zmc/zma) or `--monitor-id N` (zm-core worker).
+        if arg == "-m" || arg == "--monitor-id" {
             if let Some(id_str) = iter.next() {
                 return id_str.parse().ok();
             }
         }
     }
     None
+}
+
+/// Stable process-map id for a monitor's zm-next worker. The generated
+/// `--pipeline`/`--socket` paths ride as extra args, not in the id, so every
+/// call site derives the same key without recomputing those paths.
+fn zmnext_daemon_id(monitor_id: u32) -> String {
+    format!("zm-core --monitor-id {monitor_id}")
+}
+
+/// Recover the monitor id from a `zm-core --monitor-id N` daemon id, or `None`
+/// when `id` is not a zm-next worker id.
+fn zmnext_monitor_id_from_id(id: &str) -> Option<u32> {
+    let parts: Vec<&str> = id.split_whitespace().collect();
+    match parts.as_slice() {
+        ["zm-core", "--monitor-id", n] => n.parse().ok(),
+        _ => None,
+    }
 }
 
 /// Spawn a daemon process with PR_SET_PDEATHSIG on Linux.
@@ -2173,6 +2452,95 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_zmnext_worker_spec() {
+        // Valid, order-independent.
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&[
+                "--monitor-id",
+                "7",
+                "--pipeline",
+                "/var/lib/zm_api/pipelines/monitor_7.json",
+                "--socket",
+                "/run/zm/stream_7.sock",
+            ])
+        )
+        .is_ok());
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&[
+                "--socket",
+                "/run/zm/stream_7.sock",
+                "--pipeline",
+                "/p/monitor_7.json",
+                "--monitor-id",
+                "7",
+            ])
+        )
+        .is_ok());
+
+        // Path traversal and relative paths are rejected.
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&[
+                "--monitor-id",
+                "7",
+                "--pipeline",
+                "/p/../../etc/passwd",
+                "--socket",
+                "/run/zm/stream_7.sock",
+            ])
+        )
+        .is_err());
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&[
+                "--monitor-id",
+                "7",
+                "--pipeline",
+                "relative.json",
+                "--socket",
+                "/s.sock"
+            ])
+        )
+        .is_err());
+
+        // Missing a required flag, non-numeric id, and odd arg count all fail.
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&["--monitor-id", "7", "--pipeline", "/p.json"])
+        )
+        .is_err());
+        assert!(validate_daemon_spec(
+            "zm-core",
+            &args(&[
+                "--monitor-id",
+                "x",
+                "--pipeline",
+                "/p.json",
+                "--socket",
+                "/s.sock"
+            ])
+        )
+        .is_err());
+        assert!(validate_daemon_spec("zm-core", &args(&["--monitor-id"])).is_err());
+    }
+
+    #[test]
+    fn test_zmnext_daemon_id_round_trips() {
+        let id = zmnext_daemon_id(42);
+        assert_eq!(id, "zm-core --monitor-id 42");
+        assert_eq!(zmnext_monitor_id_from_id(&id), Some(42));
+        // Non-worker ids are rejected.
+        assert_eq!(zmnext_monitor_id_from_id("zmc -m 42"), None);
+        assert_eq!(zmnext_monitor_id_from_id("zm-core -m 42"), None);
+        // The worker id parses back to the same exec arg list.
+        let (command, parsed) = parse_daemon_command(&id, &[]);
+        assert_eq!(command, "zm-core");
+        assert_eq!(parsed, vec!["--monitor-id".to_string(), "42".to_string()]);
+    }
+
+    #[test]
     fn test_validate_daemon_spec_rejects_injection_attempts() {
         // Absolute paths are the main attack vector against PathBuf::join
         assert!(validate_daemon_spec("/bin/bash", &args(&["-c", "id"])).is_err());
@@ -2264,6 +2632,16 @@ mod tests {
         assert_eq!(
             extract_monitor_id(&["-d".to_string(), "/dev/video0".to_string()]),
             None
+        );
+        // The zm-core worker uses the long flag form.
+        assert_eq!(
+            extract_monitor_id(&[
+                "--monitor-id".to_string(),
+                "9".to_string(),
+                "--pipeline".to_string(),
+                "/p.json".to_string(),
+            ]),
+            Some(9)
         );
         assert_eq!(extract_monitor_id(&[]), None);
     }

--- a/src/repo/monitors.rs
+++ b/src/repo/monitors.rs
@@ -150,3 +150,32 @@ where
     let monitor = entity::monitors::Entity::find_by_id(id).one(conn).await?;
     Ok(monitor)
 }
+
+/// Read a monitor's `UseZmNext` flag.
+///
+/// Deliberately a standalone raw query rather than a column on the generated
+/// `monitors` entity: SeaORM selects every modelled column, so adding
+/// `UseZmNext` to the entity would break *every* monitor query against a DB
+/// whose schema lacks it. The ZoneMinder fork owns that migration and has not
+/// shipped it yet, so this query degrades to `false` (legacy capture) on a
+/// missing column, missing row, or any other DB error — and starts returning
+/// the real value automatically once the column exists.
+pub async fn use_zmnext<C>(conn: &C, monitor_id: u32) -> bool
+where
+    C: ConnectionTrait,
+{
+    use sea_orm::{DbBackend, Statement};
+
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        "SELECT `UseZmNext` AS use_zm_next FROM `Monitors` WHERE `Id` = ?",
+        [monitor_id.into()],
+    );
+    match conn.query_one(stmt).await {
+        Ok(Some(row)) => row
+            .try_get::<i8>("", "use_zm_next")
+            .map(|v| v != 0)
+            .unwrap_or(false),
+        _ => false,
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -81,9 +81,25 @@ impl AppState {
         // Initialize source router and live coordinator
         let (source_router, live_coordinator) = if config.streaming.enabled {
             tracing::info!("Live streaming enabled, initializing source router and coordinator");
-            let router = Arc::new(SourceRouter::from_zoneminder_config(
-                config.streaming.zoneminder.clone(),
-            ));
+            let mut router =
+                SourceRouter::from_zoneminder_config(config.streaming.zoneminder.clone());
+
+            // zm-next event ingest: the router forwards decoded monitor EVENTs
+            // to a bounded channel drained by a background ingest task that
+            // writes Events/Frames rows. Only wired when zm-next is enabled.
+            if config.zmnext.enabled {
+                let (event_tx, event_rx) =
+                    tokio::sync::mpsc::channel(config.zmnext.ingest.channel_capacity);
+                router.set_event_sink(event_tx);
+                let ingestor = crate::service::zmnext::EventIngestor::new(
+                    db.clone(),
+                    config.zmnext.ingest.clone(),
+                );
+                tokio::spawn(ingestor.run(event_rx));
+                tracing::info!("zm-next event ingest enabled");
+            }
+
+            let router = Arc::new(router);
             let coordinator = Arc::new(LiveStreamCoordinator::new(
                 Arc::clone(&router),
                 hls_session_manager.clone(),
@@ -108,11 +124,17 @@ impl AppState {
         // Initialize daemon manager if enabled
         let daemon_manager = if config.daemon.enabled {
             tracing::info!("Daemon controller enabled, initializing manager");
-            Some(Arc::new(DaemonManager::with_database(
+            let mut manager = DaemonManager::with_database(
                 config.daemon.clone(),
                 None, // Server ID can be set from DB config later
                 db.clone(),
-            )))
+            );
+            // Enable zm-next worker control (no-op unless [zmnext].enabled).
+            manager.set_zmnext(
+                config.zmnext.clone(),
+                config.streaming.zoneminder.socks_path.clone(),
+            );
+            Some(Arc::new(manager))
         } else {
             tracing::info!("Daemon controller disabled in configuration");
             None

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -44,5 +44,6 @@ pub mod token;
 pub mod triggers_x10;
 pub mod user_preferences;
 pub mod users;
+pub mod zmnext;
 pub mod zone_presets;
 pub mod zones;

--- a/src/service/zmnext/detail.rs
+++ b/src/service/zmnext/detail.rs
@@ -6,7 +6,8 @@
 //!
 //! * `0x0301 detection`   → [`DetectionDetail`]   (object list + source frame)
 //! * `0x0302 description` → [`DescriptionDetail`] (the raw `describe_vlm` event)
-//! * `0x0303 recording_saved` → [`RecordingSavedDetail`] (the `store_event`
+//! * `0x0304 recording_opening` → [`RecordingOpeningDetail`] (id-assignment request)
+//! * `0x0303 recording_saved` → [`RecordingSavedDetail`] (the `store` plugin's
 //!   `EventClip` document)
 //!
 //! Every field is optional / defaulted: zm-next is free to add keys (the wire
@@ -95,9 +96,11 @@ impl DescriptionDetail {
     }
 }
 
-/// `recording_opening` (0x0304) `json_detail` — emitted when `store_event`
+/// `recording_opening` (0x0304) `json_detail` — emitted when the `store` plugin
 /// begins a segment and needs an event id + target path assigned. `clip_token`
-/// is store_event's opaque correlation handle, echoed back in the reply.
+/// is its opaque correlation handle, echoed back in the reply. `trigger` is
+/// `"continuous"` for a continuous segment, else the trigger type
+/// (`"detection"`, `"motion"`, `"audio_event"`, `"tracked_detection"`, …).
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct RecordingOpeningDetail {
     #[serde(default)]
@@ -112,20 +115,24 @@ impl RecordingOpeningDetail {
     }
 }
 
-/// `recording_saved` (0x0303) `json_detail` — the `store_event` `EventClip`.
+/// `recording_saved` (0x0303) `json_detail` — the `store` plugin's `EventClip`.
 ///
-/// Only the fields zm-api indexes are modelled; `store_event` may emit more
+/// Only the fields zm-api indexes are modelled; the worker may emit more
 /// (kept forward-compatible by ignoring unknown keys).
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct RecordingSavedDetail {
-    /// Absolute path of the written `.mp4` clip.
+    /// Absolute path of the written `.mp4` clip (the assigned target if the
+    /// rename succeeded, else the worker's own-naming path).
     #[serde(default)]
     pub path: String,
     /// The event id zm-api assigned at `recording_opening`, echoed back so the
-    /// exact row is finalized. `None` only for clips written without the
-    /// handshake (legacy / pre-assignment).
+    /// exact row is finalized. `0` (or absent) means the clip closed before the
+    /// assignment arrived — see [`Self::assigned_event_id`].
     #[serde(default)]
     pub event_id: Option<u64>,
+    /// Cause string the worker recorded the clip under.
+    #[serde(default)]
+    pub cause: Option<String>,
     /// Clip duration in seconds.
     #[serde(default)]
     pub duration: Option<f64>,
@@ -142,6 +149,12 @@ pub struct RecordingSavedDetail {
 impl RecordingSavedDetail {
     pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
+    }
+
+    /// The assigned event id, treating `0`/absent as "not assigned" (the clip
+    /// closed before zm-api's `assign_recording` reached the worker).
+    pub fn assigned_event_id(&self) -> Option<u64> {
+        self.event_id.filter(|&id| id != 0)
     }
 
     /// The clip's file name (what ZoneMinder stores in `Events.DefaultVideo`),

--- a/src/service/zmnext/detail.rs
+++ b/src/service/zmnext/detail.rs
@@ -1,0 +1,193 @@
+//! Typed views over the zm-next EVENT `json_detail` TLV (tag `0x10`).
+//!
+//! zm-next carries its structured analysis/AI payloads as a UTF-8 JSON document
+//! in the EVENT `json_detail` field. The three analysis codes each use a
+//! different schema:
+//!
+//! * `0x0301 detection`   → [`DetectionDetail`]   (object list + source frame)
+//! * `0x0302 description` → [`DescriptionDetail`] (the raw `describe_vlm` event)
+//! * `0x0303 recording_saved` → [`RecordingSavedDetail`] (the `store_event`
+//!   `EventClip` document)
+//!
+//! Every field is optional / defaulted: zm-next is free to add keys (the wire
+//! is additive), so parsing tolerates unknown keys and missing values rather
+//! than failing — the same skip-on-unknown discipline as the binary protocol.
+
+use serde::Deserialize;
+
+/// One detected object from a `detection` event.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct DetectedObject {
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub confidence: f32,
+    #[serde(default)]
+    pub x: f32,
+    #[serde(default)]
+    pub y: f32,
+    #[serde(default)]
+    pub w: f32,
+    #[serde(default)]
+    pub h: f32,
+    /// Persistent tracker id, when the pipeline includes a tracker stage.
+    #[serde(default)]
+    pub track_id: Option<i64>,
+    /// ZoneMinder zone the detection fell in, when zone mapping is enabled.
+    #[serde(default)]
+    pub zone_id: Option<u32>,
+}
+
+/// `detection` (0x0301) `json_detail`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct DetectionDetail {
+    #[serde(default)]
+    pub objects: Vec<DetectedObject>,
+    /// pts (microseconds) of the frame the detection ran on.
+    #[serde(default)]
+    pub frame_pts_us: Option<i64>,
+}
+
+impl DetectionDetail {
+    pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    /// A short, human-readable cause string ("person, car") for the Event row,
+    /// de-duplicated and order-preserving. Empty when there are no objects.
+    pub fn cause_summary(&self) -> String {
+        let mut labels: Vec<&str> = Vec::new();
+        for obj in &self.objects {
+            let label = obj.label.trim();
+            if !label.is_empty() && !labels.contains(&label) {
+                labels.push(label);
+            }
+        }
+        labels.join(", ")
+    }
+
+    /// Highest confidence across all objects, scaled to ZoneMinder's 0–100
+    /// integer score domain. 0 when there are no objects.
+    pub fn peak_score(&self) -> u16 {
+        let peak = self
+            .objects
+            .iter()
+            .map(|o| o.confidence)
+            .fold(0.0f32, f32::max);
+        (peak.clamp(0.0, 1.0) * 100.0).round() as u16
+    }
+}
+
+/// `description` (0x0302) `json_detail` — the raw `describe_vlm` event.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct DescriptionDetail {
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+impl DescriptionDetail {
+    pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+/// `recording_saved` (0x0303) `json_detail` — the `store_event` `EventClip`.
+///
+/// Only the fields zm-api indexes are modelled; `store_event` may emit more
+/// (kept forward-compatible by ignoring unknown keys).
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct RecordingSavedDetail {
+    /// Absolute path of the written `.mp4` clip.
+    #[serde(default)]
+    pub path: String,
+    /// Clip duration in seconds.
+    #[serde(default)]
+    pub duration: Option<f64>,
+    /// Total frames written, when the muxer reports it.
+    #[serde(default)]
+    pub frames: Option<u32>,
+    /// Unix-epoch seconds of the first / last frame, when present.
+    #[serde(default)]
+    pub start_time: Option<f64>,
+    #[serde(default)]
+    pub end_time: Option<f64>,
+}
+
+impl RecordingSavedDetail {
+    pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    /// The clip's file name (what ZoneMinder stores in `Events.DefaultVideo`),
+    /// derived from the reported absolute path. Empty when `path` is empty.
+    pub fn file_name(&self) -> &str {
+        self.path
+            .rsplit(['/', '\\'])
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detection_parses_objects_and_summarizes() {
+        let json = r#"{
+            "objects": [
+                {"label":"person","confidence":0.91,"x":10,"y":20,"w":30,"h":40,"track_id":7,"zone_id":2},
+                {"label":"car","confidence":0.62},
+                {"label":"person","confidence":0.5}
+            ],
+            "frame_pts_us": 12345
+        }"#;
+        let d = DetectionDetail::parse(json).unwrap();
+        assert_eq!(d.objects.len(), 3);
+        assert_eq!(d.objects[0].track_id, Some(7));
+        assert_eq!(d.objects[0].zone_id, Some(2));
+        assert_eq!(d.frame_pts_us, Some(12345));
+        // De-duplicated, order-preserving.
+        assert_eq!(d.cause_summary(), "person, car");
+        // Peak confidence 0.91 → 91.
+        assert_eq!(d.peak_score(), 91);
+    }
+
+    #[test]
+    fn detection_tolerates_unknown_keys_and_empty() {
+        let json = r#"{"objects":[],"model":"yolo26n","extra":{"nested":true}}"#;
+        let d = DetectionDetail::parse(json).unwrap();
+        assert!(d.objects.is_empty());
+        assert_eq!(d.cause_summary(), "");
+        assert_eq!(d.peak_score(), 0);
+    }
+
+    #[test]
+    fn description_parses_text() {
+        let json =
+            r#"{"text":"A person walks past a parked car.","prompt":"Describe","model":"qwen"}"#;
+        let d = DescriptionDetail::parse(json).unwrap();
+        assert_eq!(d.text, "A person walks past a parked car.");
+        assert_eq!(d.model.as_deref(), Some("qwen"));
+    }
+
+    #[test]
+    fn recording_saved_parses_path_and_filename() {
+        let json = r#"{"event":"EventClip","path":"/var/lib/zm/events/3/2026-06-21/512/512-video.mp4","duration":12.5,"frames":300}"#;
+        let r = RecordingSavedDetail::parse(json).unwrap();
+        assert_eq!(r.duration, Some(12.5));
+        assert_eq!(r.frames, Some(300));
+        assert_eq!(r.file_name(), "512-video.mp4");
+    }
+
+    #[test]
+    fn recording_saved_empty_path_has_no_filename() {
+        let r = RecordingSavedDetail::default();
+        assert_eq!(r.file_name(), "");
+    }
+}

--- a/src/service/zmnext/detail.rs
+++ b/src/service/zmnext/detail.rs
@@ -95,6 +95,23 @@ impl DescriptionDetail {
     }
 }
 
+/// `recording_opening` (0x0304) `json_detail` — emitted when `store_event`
+/// begins a segment and needs an event id + target path assigned. `clip_token`
+/// is store_event's opaque correlation handle, echoed back in the reply.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct RecordingOpeningDetail {
+    #[serde(default)]
+    pub clip_token: String,
+    #[serde(default)]
+    pub trigger: Option<String>,
+}
+
+impl RecordingOpeningDetail {
+    pub fn parse(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
 /// `recording_saved` (0x0303) `json_detail` — the `store_event` `EventClip`.
 ///
 /// Only the fields zm-api indexes are modelled; `store_event` may emit more
@@ -104,6 +121,11 @@ pub struct RecordingSavedDetail {
     /// Absolute path of the written `.mp4` clip.
     #[serde(default)]
     pub path: String,
+    /// The event id zm-api assigned at `recording_opening`, echoed back so the
+    /// exact row is finalized. `None` only for clips written without the
+    /// handshake (legacy / pre-assignment).
+    #[serde(default)]
+    pub event_id: Option<u64>,
     /// Clip duration in seconds.
     #[serde(default)]
     pub duration: Option<f64>,
@@ -189,5 +211,23 @@ mod tests {
     fn recording_saved_empty_path_has_no_filename() {
         let r = RecordingSavedDetail::default();
         assert_eq!(r.file_name(), "");
+    }
+
+    #[test]
+    fn recording_opening_parses_clip_token() {
+        let o = RecordingOpeningDetail::parse(r#"{"clip_token":"abc-123","trigger":"detection"}"#)
+            .unwrap();
+        assert_eq!(o.clip_token, "abc-123");
+        assert_eq!(o.trigger.as_deref(), Some("detection"));
+    }
+
+    #[test]
+    fn recording_saved_echoes_assigned_event_id() {
+        let r = RecordingSavedDetail::parse(
+            r#"{"event":"EventClip","event_id":512,"path":"/e/3/d/512/512-video.mp4","duration":9.0}"#,
+        )
+        .unwrap();
+        assert_eq!(r.event_id, Some(512));
+        assert_eq!(r.file_name(), "512-video.mp4");
     }
 }

--- a/src/service/zmnext/ingest.rs
+++ b/src/service/zmnext/ingest.rs
@@ -247,10 +247,13 @@ impl EventIngestor {
             .and_then(|j| RecordingOpeningDetail::parse(j).ok())
             .unwrap_or_default();
         let when = event_time(ev);
+        let cause = cause_from_trigger(detail.trigger.as_deref());
 
         // Adopt an event already opened by an earlier detection, else create
         // one now. Either way the id is what store_event will name the clip.
-        let event_id = self.ensure_open_event(monitor_id, when, None).await?;
+        let event_id = self
+            .ensure_open_event(monitor_id, when, Some(cause.clone()))
+            .await?;
         let start = self.open.get(&monitor_id).map(|o| o.start).unwrap_or(when);
         let dims = self.monitor_dims(monitor_id).await?;
 
@@ -262,9 +265,12 @@ impl EventIngestor {
             return Ok(());
         };
 
-        // Record the Medium-scheme video name so playback derives the same path.
+        // Record the Medium-scheme video name + the cause so playback derives
+        // the same path (Cause is set here even when the row was opened by an
+        // earlier detection, so it reflects the recording trigger).
         events::ActiveModel {
             id: Set(event_id),
+            cause: Set(Some(cause)),
             scheme: Set(Scheme::Medium),
             default_video: Set(video_name.clone()),
             ..Default::default()
@@ -303,15 +309,19 @@ impl EventIngestor {
             .unwrap_or_default();
         let end = event_time(ev);
 
-        // Prefer the echoed event id from the handshake; fall back to the open
-        // session, or index a standalone clip if neither is available (e.g.
-        // zm-api restarted mid-event).
+        // Prefer the echoed event id from the handshake (treating 0/absent as
+        // "no assignment"); fall back to the open session, or index a standalone
+        // clip if neither is available (clip closed before assign / zm-api
+        // restarted mid-event).
         let event_id = match detail
-            .event_id
+            .assigned_event_id()
             .or_else(|| self.open.get(&monitor_id).map(|o| o.event_id))
         {
             Some(id) => id,
-            None => self.ensure_open_event(monitor_id, end, None).await?,
+            None => {
+                let cause = detail.cause.clone().map(|c| cause_from_trigger(Some(&c)));
+                self.ensure_open_event(monitor_id, end, cause).await?
+            }
         };
 
         let mut model = events::ActiveModel {
@@ -461,6 +471,26 @@ fn decimal_seconds(seconds: f64) -> Decimal {
     Decimal::from_f64_retain(seconds.max(0.0)).unwrap_or(Decimal::ZERO)
 }
 
+/// Map a `recording_opening` trigger to a ZoneMinder `Cause` string:
+/// "continuous" → "Continuous", motion/detection triggers to their familiar ZM
+/// causes, anything else passed through (capitalized). Absent → "Event".
+fn cause_from_trigger(trigger: Option<&str>) -> String {
+    match trigger.map(str::trim).unwrap_or("") {
+        "" => "Event".to_string(),
+        "continuous" => "Continuous".to_string(),
+        "motion" => "Motion".to_string(),
+        "detection" | "tracked_detection" => "Detection".to_string(),
+        "audio_event" => "Audio".to_string(),
+        other => {
+            let mut c = other.chars();
+            match c.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + c.as_str(),
+                None => "Event".to_string(),
+            }
+        }
+    }
+}
+
 fn non_empty(s: String) -> Option<String> {
     if s.trim().is_empty() {
         None
@@ -506,6 +536,19 @@ mod tests {
     fn non_empty_filters_blank() {
         assert_eq!(non_empty("  ".to_string()), None);
         assert_eq!(non_empty("x".to_string()), Some("x".to_string()));
+    }
+
+    #[test]
+    fn cause_from_trigger_maps_known_and_unknown() {
+        assert_eq!(cause_from_trigger(Some("continuous")), "Continuous");
+        assert_eq!(cause_from_trigger(Some("motion")), "Motion");
+        assert_eq!(cause_from_trigger(Some("detection")), "Detection");
+        assert_eq!(cause_from_trigger(Some("tracked_detection")), "Detection");
+        assert_eq!(cause_from_trigger(Some("audio_event")), "Audio");
+        // Unknown trigger is passed through, capitalized.
+        assert_eq!(cause_from_trigger(Some("linecross")), "Linecross");
+        assert_eq!(cause_from_trigger(None), "Event");
+        assert_eq!(cause_from_trigger(Some("  ")), "Event");
     }
 
     #[test]

--- a/src/service/zmnext/ingest.rs
+++ b/src/service/zmnext/ingest.rs
@@ -6,22 +6,25 @@
 //! the legacy `zmc`/`zma` daemons produce, so zm-next activity shows up on the
 //! existing REST surface unchanged.
 //!
-//! ## Correlation model
+//! ## Correlation model & id-assignment handshake
 //!
-//! The wire protocol carries no event id on EVENT frames, so events are
-//! correlated per monitor as a *session*: the first `detection` (or
-//! `description`) opens an `Events` row; subsequent detections append alarm
-//! `Frames` and bump the score aggregates; `recording_saved` finalizes the row
-//! with the clip's file name, duration and end time, then closes the session.
-//! At most one event is open per monitor at a time — matching ZoneMinder's own
+//! A recording segment is the unit of correlation, anchored by an event id that
+//! zm-api owns end to end:
+//!
+//! 1. `recording_opening` (store_event began a segment) → zm-api allocates (or
+//!    adopts) the `Events` row, computes the Medium-scheme clip location from
+//!    `Storage.Path` + the start date + the row id, and replies with a
+//!    `0x11 Command` `assign_recording` carrying `event_id`, `dir` and
+//!    `video_name`. store_event writes the clip exactly there, so ZoneMinder's
+//!    own path derivation resolves it with no schema change.
+//! 2. `detection` / `description` decorate the open row (alarm `Frames`, score
+//!    aggregates, notes). They also open a row on their own if they arrive
+//!    first, which `recording_opening` then adopts.
+//! 3. `recording_saved` finalizes the row — preferring the `event_id` echoed
+//!    back in its payload — with duration and end time, then closes the session.
+//!
+//! At most one event is open per monitor at a time, matching ZoneMinder's
 //! per-monitor event model.
-//!
-//! ## Storage-path contract
-//!
-//! `Events.DefaultVideo` holds only the clip's file name; ZoneMinder derives
-//! the full path from the storage row's `Path` + `Scheme` + event id. zm-next
-//! must therefore write its clip into that derived location (see the migration
-//! runbook). The absolute path zm-next reports is logged for auditing.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -32,10 +35,12 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
-use super::detail::{DescriptionDetail, DetectionDetail, RecordingSavedDetail};
+use super::detail::{
+    DescriptionDetail, DetectionDetail, RecordingOpeningDetail, RecordingSavedDetail,
+};
 use crate::configure::zmnext::IngestConfig;
 use crate::entity::sea_orm_active_enums::{FrameType, Scheme};
-use crate::entity::{events, frames, monitors};
+use crate::entity::{events, frames, monitors, storage};
 use crate::error::AppResult;
 use crate::streaming::source::{protocol, MonitorEvent, MonitorEventEnvelope};
 
@@ -81,13 +86,15 @@ impl OpenEvent {
     }
 }
 
-/// Cached monitor attributes needed to open an Events row, so the common path
-/// does not re-query the Monitors table per event.
-#[derive(Debug, Clone, Copy)]
+/// Cached monitor attributes needed to open and locate an Events row, so the
+/// common path does not re-query the Monitors/Storage tables per event.
+#[derive(Debug, Clone)]
 struct MonitorDims {
     width: u16,
     height: u16,
     storage_id: Option<u16>,
+    /// Filesystem root of the resolved storage (for building the clip path).
+    storage_path: Option<String>,
 }
 
 /// Consumes [`MonitorEventEnvelope`]s and writes Events/Frames rows.
@@ -128,6 +135,10 @@ impl EventIngestor {
         match env.event.code {
             protocol::EVENT_DETECTION => self.handle_detection(monitor_id, &env.event).await,
             protocol::EVENT_DESCRIPTION => self.handle_description(monitor_id, &env.event).await,
+            protocol::EVENT_RECORDING_OPENING => {
+                self.handle_recording_opening(monitor_id, &env.event, &env.reply)
+                    .await
+            }
             protocol::EVENT_RECORDING_SAVED => {
                 self.handle_recording_saved(monitor_id, &env.event).await
             }
@@ -220,6 +231,66 @@ impl EventIngestor {
         Ok(())
     }
 
+    /// store_event opened a recording segment: allocate (or adopt) the event
+    /// row, set its Medium-scheme video name, and reply with the event id +
+    /// target directory so store_event writes the clip where ZoneMinder will
+    /// later resolve it. This is the id-assignment handshake.
+    async fn handle_recording_opening(
+        &mut self,
+        monitor_id: u32,
+        ev: &MonitorEvent,
+        reply: &crate::streaming::source::router::ControlReply,
+    ) -> AppResult<()> {
+        let detail = ev
+            .json_detail
+            .as_deref()
+            .and_then(|j| RecordingOpeningDetail::parse(j).ok())
+            .unwrap_or_default();
+        let when = event_time(ev);
+
+        // Adopt an event already opened by an earlier detection, else create
+        // one now. Either way the id is what store_event will name the clip.
+        let event_id = self.ensure_open_event(monitor_id, when, None).await?;
+        let start = self.open.get(&monitor_id).map(|o| o.start).unwrap_or(when);
+        let dims = self.monitor_dims(monitor_id).await?;
+
+        let Some((dir, video_name)) = Self::clip_path(&dims, monitor_id, event_id, start) else {
+            warn!(
+                "zm-next ingest: monitor {monitor_id} has no resolvable storage path; \
+                 cannot assign a clip path for event {event_id}"
+            );
+            return Ok(());
+        };
+
+        // Record the Medium-scheme video name so playback derives the same path.
+        events::ActiveModel {
+            id: Set(event_id),
+            scheme: Set(Scheme::Medium),
+            default_video: Set(video_name.clone()),
+            ..Default::default()
+        }
+        .update(&*self.db)
+        .await?;
+
+        let command = serde_json::json!({
+            "cmd": "assign_recording",
+            "clip_token": detail.clip_token,
+            "event_id": event_id,
+            "dir": dir,
+            "video_name": video_name,
+        })
+        .to_string();
+        if !reply.send_command_json(&command) {
+            warn!(
+                "zm-next ingest: monitor {monitor_id} could not deliver assign_recording \
+                 for event {event_id} (connection gone)"
+            );
+        } else {
+            debug!("zm-next ingest: assigned event {event_id} → {dir}/{video_name}");
+        }
+        Ok(())
+    }
+
     async fn handle_recording_saved(
         &mut self,
         monitor_id: u32,
@@ -232,10 +303,14 @@ impl EventIngestor {
             .unwrap_or_default();
         let end = event_time(ev);
 
-        // Finalize the open session, or index a standalone clip if none is open
-        // (e.g. zm-api restarted mid-event).
-        let event_id = match self.open.get(&monitor_id) {
-            Some(open) => open.event_id,
+        // Prefer the echoed event id from the handshake; fall back to the open
+        // session, or index a standalone clip if neither is available (e.g.
+        // zm-api restarted mid-event).
+        let event_id = match detail
+            .event_id
+            .or_else(|| self.open.get(&monitor_id).map(|o| o.event_id))
+        {
+            Some(id) => id,
             None => self.ensure_open_event(monitor_id, end, None).await?,
         };
 
@@ -282,7 +357,7 @@ impl EventIngestor {
             start_date_time: Set(Some(start)),
             width: Set(dims.width),
             height: Set(dims.height),
-            storage_id: Set(self.config.default_storage_id.or(dims.storage_id)),
+            storage_id: Set(dims.storage_id),
             scheme: Set(Scheme::Shallow),
             length: Set(Decimal::ZERO),
             default_video: Set(String::new()),
@@ -302,25 +377,68 @@ impl EventIngestor {
 
     async fn monitor_dims(&mut self, monitor_id: u32) -> AppResult<MonitorDims> {
         if let Some(d) = self.dims.get(&monitor_id) {
-            return Ok(*d);
+            return Ok(d.clone());
         }
         let dims = match monitors::Entity::find_by_id(monitor_id)
             .one(&*self.db)
             .await?
         {
-            Some(m) => MonitorDims {
-                width: m.width,
-                height: m.height,
-                storage_id: m.storage_id,
-            },
+            Some(m) => {
+                let storage_id = self.config.default_storage_id.or(m.storage_id);
+                let storage_path = self.storage_path(storage_id).await;
+                MonitorDims {
+                    width: m.width,
+                    height: m.height,
+                    storage_id,
+                    storage_path,
+                }
+            }
             None => MonitorDims {
                 width: 0,
                 height: 0,
                 storage_id: None,
+                storage_path: None,
             },
         };
-        self.dims.insert(monitor_id, dims);
+        self.dims.insert(monitor_id, dims.clone());
         Ok(dims)
+    }
+
+    /// Resolve a storage row's filesystem path: the given id, else the default
+    /// (lowest-id) storage. `None` when no storage row is found.
+    async fn storage_path(&self, storage_id: Option<u16>) -> Option<String> {
+        use sea_orm::QueryOrder;
+
+        let row = match storage_id {
+            Some(sid) if sid != 0 => storage::Entity::find_by_id(sid).one(&*self.db).await.ok()?,
+            _ => storage::Entity::find()
+                .order_by_asc(storage::Column::Id)
+                .one(&*self.db)
+                .await
+                .ok()?,
+        }?;
+        Some(row.path).filter(|p| !p.is_empty())
+    }
+
+    /// The directory + file name a clip for `event_id` must live at under the
+    /// Medium scheme: `{storage}/{monitor}/{YYYY-MM-DD}/{event_id}` +
+    /// `{event_id}-video.mp4`. This is exactly what ZoneMinder's playback
+    /// derives, so handing it to `store_event` keeps the clip natively
+    /// resolvable. `None` when the storage path is unknown.
+    fn clip_path(
+        dims: &MonitorDims,
+        monitor_id: u32,
+        event_id: u64,
+        start: NaiveDateTime,
+    ) -> Option<(String, String)> {
+        let root = dims.storage_path.as_deref()?;
+        let date = start.format("%Y-%m-%d");
+        let dir = format!(
+            "{}/{monitor_id}/{date}/{event_id}",
+            root.trim_end_matches('/')
+        );
+        let video_name = format!("{event_id}-video.mp4");
+        Some((dir, video_name))
     }
 }
 
@@ -388,5 +506,26 @@ mod tests {
     fn non_empty_filters_blank() {
         assert_eq!(non_empty("  ".to_string()), None);
         assert_eq!(non_empty("x".to_string()), Some("x".to_string()));
+    }
+
+    #[test]
+    fn clip_path_builds_medium_scheme_layout() {
+        let dims = MonitorDims {
+            width: 1920,
+            height: 1080,
+            storage_id: Some(1),
+            storage_path: Some("/var/lib/zm/events/".to_string()),
+        };
+        let start = micros_to_naive(1_700_000_000_000_000).unwrap(); // 2023-11-14 22:13:20 UTC
+        let (dir, name) = EventIngestor::clip_path(&dims, 3, 512, start).unwrap();
+        assert_eq!(dir, "/var/lib/zm/events/3/2023-11-14/512");
+        assert_eq!(name, "512-video.mp4");
+
+        // No storage path → cannot place the clip.
+        let no_storage = MonitorDims {
+            storage_path: None,
+            ..dims
+        };
+        assert!(EventIngestor::clip_path(&no_storage, 3, 512, start).is_none());
     }
 }

--- a/src/service/zmnext/ingest.rs
+++ b/src/service/zmnext/ingest.rs
@@ -1,0 +1,392 @@
+//! Ingest of zm-next analysis EVENTs into ZoneMinder's `Events`/`Frames` rows.
+//!
+//! zm-next never touches the database — zm-api is the only writer. The source
+//! router decodes monitor EVENTs off the stream socket and forwards them here
+//! as [`MonitorEventEnvelope`]s; this task maps them onto the same Events model
+//! the legacy `zmc`/`zma` daemons produce, so zm-next activity shows up on the
+//! existing REST surface unchanged.
+//!
+//! ## Correlation model
+//!
+//! The wire protocol carries no event id on EVENT frames, so events are
+//! correlated per monitor as a *session*: the first `detection` (or
+//! `description`) opens an `Events` row; subsequent detections append alarm
+//! `Frames` and bump the score aggregates; `recording_saved` finalizes the row
+//! with the clip's file name, duration and end time, then closes the session.
+//! At most one event is open per monitor at a time — matching ZoneMinder's own
+//! per-monitor event model.
+//!
+//! ## Storage-path contract
+//!
+//! `Events.DefaultVideo` holds only the clip's file name; ZoneMinder derives
+//! the full path from the storage row's `Path` + `Scheme` + event id. zm-next
+//! must therefore write its clip into that derived location (see the migration
+//! runbook). The absolute path zm-next reports is logged for auditing.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use rust_decimal::Decimal;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use super::detail::{DescriptionDetail, DetectionDetail, RecordingSavedDetail};
+use crate::configure::zmnext::IngestConfig;
+use crate::entity::sea_orm_active_enums::{FrameType, Scheme};
+use crate::entity::{events, frames, monitors};
+use crate::error::AppResult;
+use crate::streaming::source::{protocol, MonitorEvent, MonitorEventEnvelope};
+
+/// In-memory aggregate for the event currently open on a monitor.
+#[derive(Debug, Clone, PartialEq)]
+struct OpenEvent {
+    event_id: u64,
+    start: NaiveDateTime,
+    frames: u32,
+    alarm_frames: u32,
+    tot_score: u64,
+    max_score: u16,
+}
+
+impl OpenEvent {
+    fn new(event_id: u64, start: NaiveDateTime) -> Self {
+        Self {
+            event_id,
+            start,
+            frames: 0,
+            alarm_frames: 0,
+            tot_score: 0,
+            max_score: 0,
+        }
+    }
+
+    /// Fold one detection's score into the running aggregate and return the
+    /// new frame number (1-based).
+    fn record_detection(&mut self, score: u16) -> u32 {
+        self.frames += 1;
+        self.alarm_frames += 1;
+        self.tot_score += score as u64;
+        self.max_score = self.max_score.max(score);
+        self.frames
+    }
+
+    fn avg_score(&self) -> u16 {
+        if self.frames == 0 {
+            0
+        } else {
+            (self.tot_score / self.frames as u64) as u16
+        }
+    }
+}
+
+/// Cached monitor attributes needed to open an Events row, so the common path
+/// does not re-query the Monitors table per event.
+#[derive(Debug, Clone, Copy)]
+struct MonitorDims {
+    width: u16,
+    height: u16,
+    storage_id: Option<u16>,
+}
+
+/// Consumes [`MonitorEventEnvelope`]s and writes Events/Frames rows.
+pub struct EventIngestor {
+    db: Arc<DatabaseConnection>,
+    config: IngestConfig,
+    open: HashMap<u32, OpenEvent>,
+    dims: HashMap<u32, MonitorDims>,
+}
+
+impl EventIngestor {
+    pub fn new(db: Arc<DatabaseConnection>, config: IngestConfig) -> Self {
+        Self {
+            db,
+            config,
+            open: HashMap::new(),
+            dims: HashMap::new(),
+        }
+    }
+
+    /// Drain the channel until all senders drop. Per-event DB failures are
+    /// logged and skipped; the task itself only ends when the router is gone.
+    pub async fn run(mut self, mut rx: mpsc::Receiver<MonitorEventEnvelope>) {
+        info!("zm-next event ingest task started");
+        while let Some(env) = rx.recv().await {
+            if let Err(e) = self.handle(&env).await {
+                warn!(
+                    "zm-next ingest: monitor {} event {:#06x} failed: {}",
+                    env.monitor_id, env.event.code, e
+                );
+            }
+        }
+        info!("zm-next event ingest task stopped (router dropped)");
+    }
+
+    async fn handle(&mut self, env: &MonitorEventEnvelope) -> AppResult<()> {
+        let monitor_id = env.monitor_id;
+        match env.event.code {
+            protocol::EVENT_DETECTION => self.handle_detection(monitor_id, &env.event).await,
+            protocol::EVENT_DESCRIPTION => self.handle_description(monitor_id, &env.event).await,
+            protocol::EVENT_RECORDING_SAVED => {
+                self.handle_recording_saved(monitor_id, &env.event).await
+            }
+            // Lifecycle codes: an explicit return to a non-recording state ends
+            // any open session; the rest are advisory and just logged.
+            protocol::EVENT_STATE_CHANGED
+            | protocol::EVENT_CONNECTION_FAILED
+            | protocol::EVENT_CAPTURE_FAILED => {
+                debug!(
+                    "zm-next ingest: monitor {} lifecycle {:#06x} ({:?})",
+                    monitor_id, env.event.code, env.event.state_name
+                );
+                Ok(())
+            }
+            other => {
+                debug!("zm-next ingest: monitor {monitor_id} ignoring event {other:#06x}");
+                Ok(())
+            }
+        }
+    }
+
+    async fn handle_detection(&mut self, monitor_id: u32, ev: &MonitorEvent) -> AppResult<()> {
+        let detail = ev
+            .json_detail
+            .as_deref()
+            .and_then(|j| DetectionDetail::parse(j).ok())
+            .unwrap_or_default();
+        let when = event_time(ev);
+        let cause = non_empty(detail.cause_summary());
+        let score = detail.peak_score();
+
+        let event_id = self.ensure_open_event(monitor_id, when, cause).await?;
+
+        // Fold the detection into the running aggregate, then persist a frame
+        // and the updated event totals.
+        let (frame_no, agg) = {
+            let open = self
+                .open
+                .get_mut(&monitor_id)
+                .expect("session opened above");
+            let frame_no = open.record_detection(score);
+            (frame_no, open.clone())
+        };
+
+        let delta = decimal_seconds((when - agg.start).num_milliseconds() as f64 / 1000.0);
+        frames::ActiveModel {
+            event_id: Set(event_id),
+            frame_id: Set(frame_no),
+            r#type: Set(FrameType::Alarm),
+            time_stamp: Set(when.and_utc()),
+            delta: Set(delta),
+            score: Set(score),
+            ..Default::default()
+        }
+        .insert(&*self.db)
+        .await?;
+
+        events::ActiveModel {
+            id: Set(event_id),
+            frames: Set(Some(agg.frames)),
+            alarm_frames: Set(Some(agg.alarm_frames)),
+            tot_score: Set(agg.tot_score as u32),
+            avg_score: Set(Some(agg.avg_score())),
+            max_score: Set(Some(agg.max_score)),
+            ..Default::default()
+        }
+        .update(&*self.db)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn handle_description(&mut self, monitor_id: u32, ev: &MonitorEvent) -> AppResult<()> {
+        let detail = ev
+            .json_detail
+            .as_deref()
+            .and_then(|j| DescriptionDetail::parse(j).ok())
+            .unwrap_or_default();
+        let when = event_time(ev);
+        // A description on its own still implies activity worth a row.
+        let event_id = self.ensure_open_event(monitor_id, when, None).await?;
+
+        events::ActiveModel {
+            id: Set(event_id),
+            notes: Set(non_empty(detail.text)),
+            ..Default::default()
+        }
+        .update(&*self.db)
+        .await?;
+        Ok(())
+    }
+
+    async fn handle_recording_saved(
+        &mut self,
+        monitor_id: u32,
+        ev: &MonitorEvent,
+    ) -> AppResult<()> {
+        let detail = ev
+            .json_detail
+            .as_deref()
+            .and_then(|j| RecordingSavedDetail::parse(j).ok())
+            .unwrap_or_default();
+        let end = event_time(ev);
+
+        // Finalize the open session, or index a standalone clip if none is open
+        // (e.g. zm-api restarted mid-event).
+        let event_id = match self.open.get(&monitor_id) {
+            Some(open) => open.event_id,
+            None => self.ensure_open_event(monitor_id, end, None).await?,
+        };
+
+        let mut model = events::ActiveModel {
+            id: Set(event_id),
+            end_date_time: Set(Some(end)),
+            default_video: Set(detail.file_name().to_string()),
+            ..Default::default()
+        };
+        if let Some(d) = detail.duration {
+            model.length = Set(decimal_seconds(d));
+        }
+        if let Some(f) = detail.frames {
+            model.frames = Set(Some(f));
+        }
+        model.update(&*self.db).await?;
+
+        info!(
+            "zm-next ingest: monitor {monitor_id} indexed clip {:?} ({}s) → event {event_id}",
+            detail.path,
+            detail.duration.unwrap_or(0.0)
+        );
+        self.open.remove(&monitor_id);
+        Ok(())
+    }
+
+    /// Return the open event's id for `monitor_id`, creating the Events row (and
+    /// caching the session) if none is open.
+    async fn ensure_open_event(
+        &mut self,
+        monitor_id: u32,
+        start: NaiveDateTime,
+        cause: Option<String>,
+    ) -> AppResult<u64> {
+        if let Some(open) = self.open.get(&monitor_id) {
+            return Ok(open.event_id);
+        }
+
+        let dims = self.monitor_dims(monitor_id).await?;
+        let model = events::ActiveModel {
+            monitor_id: Set(monitor_id),
+            name: Set(self.config.event_name.clone()),
+            cause: Set(cause),
+            start_date_time: Set(Some(start)),
+            width: Set(dims.width),
+            height: Set(dims.height),
+            storage_id: Set(self.config.default_storage_id.or(dims.storage_id)),
+            scheme: Set(Scheme::Shallow),
+            length: Set(Decimal::ZERO),
+            default_video: Set(String::new()),
+            ..Default::default()
+        }
+        .insert(&*self.db)
+        .await?;
+
+        debug!(
+            "zm-next ingest: opened event {} for monitor {monitor_id}",
+            model.id
+        );
+        self.open
+            .insert(monitor_id, OpenEvent::new(model.id, start));
+        Ok(model.id)
+    }
+
+    async fn monitor_dims(&mut self, monitor_id: u32) -> AppResult<MonitorDims> {
+        if let Some(d) = self.dims.get(&monitor_id) {
+            return Ok(*d);
+        }
+        let dims = match monitors::Entity::find_by_id(monitor_id)
+            .one(&*self.db)
+            .await?
+        {
+            Some(m) => MonitorDims {
+                width: m.width,
+                height: m.height,
+                storage_id: m.storage_id,
+            },
+            None => MonitorDims {
+                width: 0,
+                height: 0,
+                storage_id: None,
+            },
+        };
+        self.dims.insert(monitor_id, dims);
+        Ok(dims)
+    }
+}
+
+/// EVENT timestamp to use for a row: the wall-clock TLV when present, else now.
+fn event_time(ev: &MonitorEvent) -> NaiveDateTime {
+    ev.wall_clock_us
+        .and_then(micros_to_naive)
+        .unwrap_or_else(|| Utc::now().naive_utc())
+}
+
+/// Convert unix-epoch microseconds to a naive-UTC datetime.
+fn micros_to_naive(us: u64) -> Option<NaiveDateTime> {
+    let secs = (us / 1_000_000) as i64;
+    let nanos = ((us % 1_000_000) * 1_000) as u32;
+    DateTime::<Utc>::from_timestamp(secs, nanos).map(|dt| dt.naive_utc())
+}
+
+/// Seconds (possibly fractional) as a ZoneMinder `Decimal`, clamped at 0.
+fn decimal_seconds(seconds: f64) -> Decimal {
+    Decimal::from_f64_retain(seconds.max(0.0)).unwrap_or(Decimal::ZERO)
+}
+
+fn non_empty(s: String) -> Option<String> {
+    if s.trim().is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_event_aggregates_scores() {
+        let start = micros_to_naive(1_700_000_000_000_000).unwrap();
+        let mut open = OpenEvent::new(42, start);
+
+        assert_eq!(open.record_detection(80), 1);
+        assert_eq!(open.record_detection(40), 2);
+        assert_eq!(open.record_detection(90), 3);
+
+        assert_eq!(open.frames, 3);
+        assert_eq!(open.alarm_frames, 3);
+        assert_eq!(open.tot_score, 210);
+        assert_eq!(open.max_score, 90);
+        assert_eq!(open.avg_score(), 70);
+    }
+
+    #[test]
+    fn micros_round_trip_to_known_instant() {
+        // 2023-11-14T22:13:20 UTC
+        let dt = micros_to_naive(1_700_000_000_000_000).unwrap();
+        assert_eq!(dt.and_utc().timestamp(), 1_700_000_000);
+    }
+
+    #[test]
+    fn decimal_seconds_clamps_negative() {
+        assert_eq!(decimal_seconds(-3.0), Decimal::ZERO);
+        assert_eq!(decimal_seconds(12.5).to_string(), "12.5");
+    }
+
+    #[test]
+    fn non_empty_filters_blank() {
+        assert_eq!(non_empty("  ".to_string()), None);
+        assert_eq!(non_empty("x".to_string()), Some("x".to_string()));
+    }
+}

--- a/src/service/zmnext/mod.rs
+++ b/src/service/zmnext/mod.rs
@@ -1,0 +1,12 @@
+//! zm-api side of the zm-next worker integration.
+//!
+//! * [`detail`] — typed views over the EVENT `json_detail` JSON payloads.
+//! * [`ingest`] — maps decoded monitor EVENTs onto Events/Frames rows.
+//! * [`pipeline`] — generates a worker pipeline JSON from a monitor + its zones.
+
+pub mod detail;
+pub mod ingest;
+pub mod pipeline;
+
+pub use ingest::EventIngestor;
+pub use pipeline::generate_pipeline;

--- a/src/service/zmnext/pipeline.rs
+++ b/src/service/zmnext/pipeline.rs
@@ -3,10 +3,13 @@
 //! zm-next consumes a recursive plugin tree — `{id, kind, cfg, children}` under
 //! a top-level `{name, root, plugins}` — and never reads the database itself;
 //! zm-api is the sole DB reader and hands the worker a fully-resolved pipeline
-//! file via `--pipeline`. The shape is `capture_rtsp_multi → decode_detect →
-//! {store[, output_mqtt]}`, where `store` is zm-next's merged recorder (it
-//! folded the old `store_filesystem` + `store_event` into one mode-switched
-//! plugin).
+//! file via `--pipeline`. The shape is a `capture_rtsp_multi` root with
+//! `decode_detect`, `store`, and (optionally) `output_mqtt` as **siblings**
+//! under it. `store` is zm-next's merged recorder (it folded the old
+//! `store_filesystem` + `store_event` into one mode-switched plugin); it hangs
+//! off `capture` — not under `decode_detect` — so it records the captured main
+//! stream rather than the detector's substream (triggers reach it over
+//! zm-next's process-global event bus regardless of tree position).
 //!
 //! The Monitor's `Path` column already holds the full RTSP URL (credentials
 //! embedded) that zm-api uses everywhere else, so it is used verbatim as the
@@ -142,14 +145,29 @@ pub fn generate_pipeline(
         store_cfg["max_buffer_sec"] = json!(cfg.max_buffer_sec);
         store_cfg["trigger_types"] = json!(cfg.trigger_types);
     }
-    let mut detect_children = vec![json!({
-        "id": "record",
-        "kind": "store",
-        "cfg": store_cfg,
-        "queue_depth": 120,
-    })];
+
+    // `store` and `output_mqtt` are siblings of `decode_detect` under `capture`,
+    // not children of it: in zm-next, EVENTs (triggers, assign_recording) flow
+    // on a process-global bus regardless of tree position, while tree position
+    // only decides which FRAMES a plugin sees. `store` must record the captured
+    // (main) stream, so it hangs off `capture`; were it under `decode_detect` it
+    // would record whatever that stage is fed (the low-res substream).
+    let mut capture_children = vec![
+        json!({
+            "id": "detect",
+            "kind": "decode_detect",
+            "cfg": detect_cfg,
+            "queue_depth": 2,
+        }),
+        json!({
+            "id": "record",
+            "kind": "store",
+            "cfg": store_cfg,
+            "queue_depth": 120,
+        }),
+    ];
     if let Some((host, port)) = mqtt_host_port(cfg.mqtt_url.as_deref()) {
-        detect_children.push(json!({
+        capture_children.push(json!({
             "id": "notify",
             "kind": "output_mqtt",
             "cfg": { "host": host, "port": port, "base_topic": "zm-next" },
@@ -171,13 +189,7 @@ pub fn generate_pipeline(
                     "max_retry_attempts": -1,
                 }],
             },
-            "children": [{
-                "id": "detect",
-                "kind": "decode_detect",
-                "cfg": detect_cfg,
-                "queue_depth": 2,
-                "children": detect_children,
-            }],
+            "children": capture_children,
         }],
     })
 }
@@ -296,15 +308,18 @@ mod tests {
             "rtsp://admin:pw@cam:554/Streaming/Channels/101"
         );
 
+        // detect, store, (mqtt) are siblings under capture. detect is first and
+        // has no children of its own.
         let detect = &capture["children"][0];
         assert_eq!(detect["kind"], "decode_detect");
+        assert!(detect.get("children").is_none());
         // The active zone is translated onto the detect stage.
         assert_eq!(detect["cfg"]["zones"][0]["name"], "Front");
         assert_eq!(detect["cfg"]["zones"][0]["points"][1], json!([640, 0]));
         assert_eq!(detect["cfg"]["zones"][0]["min_pixel_threshold"], 25);
 
         // One merged `store` plugin in event mode: roll/trigger keys, no max_secs.
-        let record = &detect["children"][0];
+        let record = &capture["children"][1];
         assert_eq!(record["kind"], "store");
         assert_eq!(record["cfg"]["mode"], "event");
         assert_eq!(record["cfg"]["root"], "/var/lib/zm/events");
@@ -315,8 +330,8 @@ mod tests {
         assert_eq!(record["cfg"]["max_buffer_sec"], 15);
         assert_eq!(record["cfg"]["trigger_types"][0], "detection");
         assert!(record["cfg"].get("max_secs").is_none());
-        // No MQTT broker configured → no output_mqtt child.
-        assert_eq!(detect["children"].as_array().unwrap().len(), 1);
+        // No MQTT broker configured → just detect + store under capture.
+        assert_eq!(capture["children"].as_array().unwrap().len(), 2);
     }
 
     #[test]
@@ -340,7 +355,7 @@ mod tests {
         );
 
         let cfg = test_cfg();
-        // store lives at capture → detect → store.
+        // store is a sibling of detect under capture: plugins[0].children[1].
         // Continuous: segment key present, event keys absent.
         let cont = generate_pipeline(
             1,
@@ -350,7 +365,8 @@ mod tests {
             StoreMode::Continuous,
             Path::new("/e"),
         );
-        let store = &cont["plugins"][0]["children"][0]["children"][0]["cfg"];
+        let store = &cont["plugins"][0]["children"][1]["cfg"];
+        assert_eq!(cont["plugins"][0]["children"][1]["kind"], "store");
         assert_eq!(store["mode"], "continuous");
         assert_eq!(store["max_secs"], 300);
         assert!(store.get("pre_roll_sec").is_none());
@@ -358,7 +374,7 @@ mod tests {
 
         // Both: segment AND event keys present.
         let both = generate_pipeline(1, "rtsp://c", &[], &cfg, StoreMode::Both, Path::new("/e"));
-        let store = &both["plugins"][0]["children"][0]["children"][0]["cfg"];
+        let store = &both["plugins"][0]["children"][1]["cfg"];
         assert_eq!(store["mode"], "both");
         assert_eq!(store["max_secs"], 300);
         assert_eq!(store["post_roll_sec"], 10);
@@ -378,11 +394,15 @@ mod tests {
             StoreMode::Continuous,
             Path::new("/events"),
         );
-        let detect = &p["plugins"][0]["children"][0];
-        let children = detect["children"].as_array().unwrap();
-        assert_eq!(children.len(), 2);
-        assert_eq!(children[1]["kind"], "output_mqtt");
-        assert_eq!(children[1]["cfg"]["port"], 1883);
+        let capture = &p["plugins"][0];
+        let children = capture["children"].as_array().unwrap();
+        // capture's children: detect, store, output_mqtt (all siblings).
+        assert_eq!(children.len(), 3);
+        assert_eq!(children[0]["kind"], "decode_detect");
+        assert_eq!(children[1]["kind"], "store");
+        assert_eq!(children[2]["kind"], "output_mqtt");
+        assert_eq!(children[2]["cfg"]["port"], 1883);
+        let detect = &children[0];
         // No zones supplied → the detect cfg omits the zones key entirely.
         assert!(detect["cfg"].get("zones").is_none());
     }

--- a/src/service/zmnext/pipeline.rs
+++ b/src/service/zmnext/pipeline.rs
@@ -3,9 +3,10 @@
 //! zm-next consumes a recursive plugin tree — `{id, kind, cfg, children}` under
 //! a top-level `{name, root, plugins}` — and never reads the database itself;
 //! zm-api is the sole DB reader and hands the worker a fully-resolved pipeline
-//! file via `--pipeline`. The shape mirrors the worker's own templates
-//! (`pipelines/*.template.json`): `capture_rtsp_multi → decode_detect →
-//! {store_event[, output_mqtt]}`.
+//! file via `--pipeline`. The shape is `capture_rtsp_multi → decode_detect →
+//! {store[, output_mqtt]}`, where `store` is zm-next's merged recorder (it
+//! folded the old `store_filesystem` + `store_event` into one mode-switched
+//! plugin).
 //!
 //! The Monitor's `Path` column already holds the full RTSP URL (credentials
 //! embedded) that zm-api uses everywhere else, so it is used verbatim as the
@@ -23,8 +24,49 @@ use std::path::{Path, PathBuf};
 use serde_json::{json, Value};
 
 use crate::configure::zmnext::PipelineConfig;
-use crate::entity::sea_orm_active_enums::ZoneType;
+use crate::entity::sea_orm_active_enums::{Function, ZoneType};
 use crate::entity::zones;
+
+/// Recording mode for the merged `store` plugin, derived from the monitor's
+/// ZoneMinder function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreMode {
+    /// Gapless segment recording (ZM `Record`).
+    Continuous,
+    /// Triggered pre/post-roll clips only (ZM `Modect`/`Nodect`).
+    Event,
+    /// Both continuous segments and triggered clips (ZM `Mocord`).
+    Both,
+}
+
+impl StoreMode {
+    /// Map a monitor's `Function` to a store mode. Non-recording functions
+    /// (`Monitor`/`None`) default to continuous, matching the worker default.
+    pub fn from_function(function: &Function) -> Self {
+        match function {
+            Function::Modect | Function::Nodect => StoreMode::Event,
+            Function::Mocord => StoreMode::Both,
+            // Record, Monitor, None
+            _ => StoreMode::Continuous,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            StoreMode::Continuous => "continuous",
+            StoreMode::Event => "event",
+            StoreMode::Both => "both",
+        }
+    }
+
+    fn records_continuous(self) -> bool {
+        matches!(self, StoreMode::Continuous | StoreMode::Both)
+    }
+
+    fn records_events(self) -> bool {
+        matches!(self, StoreMode::Event | StoreMode::Both)
+    }
+}
 
 /// A ZoneMinder zone reduced to what the detect stage needs.
 #[derive(Debug, Clone, PartialEq)]
@@ -54,13 +96,19 @@ pub fn zone_specs_from_models(zones: &[zones::Model]) -> Vec<ZoneSpec> {
 /// Build the pipeline JSON document for one monitor.
 ///
 /// * `source_url` — the capture RTSP URL (the monitor's `Path`).
-/// * `events_root` — directory the `store_event` stage writes clips under
-///   (the monitor's storage path, resolved from the Storage row by the caller).
+/// * `mode` — recording mode for the merged `store` plugin (from the monitor's
+///   function).
+/// * `events_root` — media root the `store` plugin writes under. **Must be on
+///   the same filesystem as the directory zm-api hands back in
+///   `assign_recording`**, because the worker renames the in-progress file into
+///   that directory with an open fd (a cross-fs target fails and the clip keeps
+///   the worker's own name).
 pub fn generate_pipeline(
     monitor_id: u32,
     source_url: &str,
     zones: &[ZoneSpec],
     cfg: &PipelineConfig,
+    mode: StoreMode,
     events_root: &Path,
 ) -> Value {
     let mut detect_cfg = json!({
@@ -75,17 +123,29 @@ pub fn generate_pipeline(
         detect_cfg["zones"] = Value::Array(zone_specs);
     }
 
-    // store_event is always present; output_mqtt only when a broker is set.
+    // The merged `store` plugin (zm-next folded store_filesystem + store_event
+    // into one). Common keys always; segment / event keys only for the modes
+    // that use them. Every segment and every clip is one ZM event and runs the
+    // id-assignment handshake.
+    let mut store_cfg = json!({
+        "mode": mode.as_str(),
+        "root": events_root.to_string_lossy(),
+        "monitor_id": monitor_id,
+        "stream_filter": [0],
+    });
+    if mode.records_continuous() {
+        store_cfg["max_secs"] = json!(cfg.segment_max_secs);
+    }
+    if mode.records_events() {
+        store_cfg["pre_roll_sec"] = json!(cfg.pre_roll_sec);
+        store_cfg["post_roll_sec"] = json!(cfg.post_roll_sec);
+        store_cfg["max_buffer_sec"] = json!(cfg.max_buffer_sec);
+        store_cfg["trigger_types"] = json!(cfg.trigger_types);
+    }
     let mut detect_children = vec![json!({
         "id": "record",
-        "kind": "store_event",
-        "cfg": {
-            "root": events_root.to_string_lossy(),
-            "monitor_id": monitor_id,
-            "trigger_types": ["detection"],
-            "pre_roll_sec": 5,
-            "post_roll_sec": 10,
-        },
+        "kind": "store",
+        "cfg": store_cfg,
         "queue_depth": 120,
     })];
     if let Some((host, port)) = mqtt_host_port(cfg.mqtt_url.as_deref()) {
@@ -223,6 +283,7 @@ mod tests {
             "rtsp://admin:pw@cam:554/Streaming/Channels/101",
             &zones,
             &cfg,
+            StoreMode::Event,
             Path::new("/var/lib/zm/events"),
         );
 
@@ -242,12 +303,65 @@ mod tests {
         assert_eq!(detect["cfg"]["zones"][0]["points"][1], json!([640, 0]));
         assert_eq!(detect["cfg"]["zones"][0]["min_pixel_threshold"], 25);
 
+        // One merged `store` plugin in event mode: roll/trigger keys, no max_secs.
         let record = &detect["children"][0];
-        assert_eq!(record["kind"], "store_event");
+        assert_eq!(record["kind"], "store");
+        assert_eq!(record["cfg"]["mode"], "event");
         assert_eq!(record["cfg"]["root"], "/var/lib/zm/events");
         assert_eq!(record["cfg"]["monitor_id"], 7);
+        assert_eq!(record["cfg"]["stream_filter"], json!([0]));
+        assert_eq!(record["cfg"]["pre_roll_sec"], 5);
+        assert_eq!(record["cfg"]["post_roll_sec"], 10);
+        assert_eq!(record["cfg"]["max_buffer_sec"], 15);
+        assert_eq!(record["cfg"]["trigger_types"][0], "detection");
+        assert!(record["cfg"].get("max_secs").is_none());
         // No MQTT broker configured → no output_mqtt child.
         assert_eq!(detect["children"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn store_mode_maps_from_function_and_emits_right_keys() {
+        assert_eq!(
+            StoreMode::from_function(&Function::Record),
+            StoreMode::Continuous
+        );
+        assert_eq!(StoreMode::from_function(&Function::Mocord), StoreMode::Both);
+        assert_eq!(
+            StoreMode::from_function(&Function::Modect),
+            StoreMode::Event
+        );
+        assert_eq!(
+            StoreMode::from_function(&Function::Nodect),
+            StoreMode::Event
+        );
+        assert_eq!(
+            StoreMode::from_function(&Function::Monitor),
+            StoreMode::Continuous
+        );
+
+        let cfg = test_cfg();
+        // store lives at capture → detect → store.
+        // Continuous: segment key present, event keys absent.
+        let cont = generate_pipeline(
+            1,
+            "rtsp://c",
+            &[],
+            &cfg,
+            StoreMode::Continuous,
+            Path::new("/e"),
+        );
+        let store = &cont["plugins"][0]["children"][0]["children"][0]["cfg"];
+        assert_eq!(store["mode"], "continuous");
+        assert_eq!(store["max_secs"], 300);
+        assert!(store.get("pre_roll_sec").is_none());
+        assert!(store.get("trigger_types").is_none());
+
+        // Both: segment AND event keys present.
+        let both = generate_pipeline(1, "rtsp://c", &[], &cfg, StoreMode::Both, Path::new("/e"));
+        let store = &both["plugins"][0]["children"][0]["children"][0]["cfg"];
+        assert_eq!(store["mode"], "both");
+        assert_eq!(store["max_secs"], 300);
+        assert_eq!(store["post_roll_sec"], 10);
     }
 
     #[test]
@@ -256,7 +370,14 @@ mod tests {
             mqtt_url: Some("mqtt://localhost:1883".to_string()),
             ..PipelineConfig::default()
         };
-        let p = generate_pipeline(1, "rtsp://cam/stream", &[], &cfg, Path::new("/events"));
+        let p = generate_pipeline(
+            1,
+            "rtsp://cam/stream",
+            &[],
+            &cfg,
+            StoreMode::Continuous,
+            Path::new("/events"),
+        );
         let detect = &p["plugins"][0]["children"][0];
         let children = detect["children"].as_array().unwrap();
         assert_eq!(children.len(), 2);

--- a/src/service/zmnext/pipeline.rs
+++ b/src/service/zmnext/pipeline.rs
@@ -1,0 +1,268 @@
+//! Generates a zm-next worker pipeline JSON from a Monitor row and its Zones.
+//!
+//! zm-next consumes a recursive plugin tree — `{id, kind, cfg, children}` under
+//! a top-level `{name, root, plugins}` — and never reads the database itself;
+//! zm-api is the sole DB reader and hands the worker a fully-resolved pipeline
+//! file via `--pipeline`. The shape mirrors the worker's own templates
+//! (`pipelines/*.template.json`): `capture_rtsp_multi → decode_detect →
+//! {store_event[, output_mqtt]}`.
+//!
+//! The Monitor's `Path` column already holds the full RTSP URL (credentials
+//! embedded) that zm-api uses everywhere else, so it is used verbatim as the
+//! capture source. ZoneMinder Zones are translated into a best-effort `zones`
+//! array on the detect stage (polygon points + pixel thresholds); evolution is
+//! additive, so unknown keys are harmless.
+//!
+//! The generator works on small plain inputs ([`ZoneSpec`]) rather than the
+//! `monitors`/`zones` entities directly, so it is fully unit-testable; the thin
+//! [`zone_specs_from_models`] mapper bridges the SeaORM models at the call site.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::configure::zmnext::PipelineConfig;
+use crate::entity::sea_orm_active_enums::ZoneType;
+use crate::entity::zones;
+
+/// A ZoneMinder zone reduced to what the detect stage needs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ZoneSpec {
+    pub name: String,
+    /// Raw `Coords` string ("x1,y1 x2,y2 ...").
+    pub coords: String,
+    pub min_pixel_threshold: Option<u16>,
+    pub max_pixel_threshold: Option<u16>,
+}
+
+/// Reduce SeaORM zone models to [`ZoneSpec`]s, dropping Inactive and Privacy
+/// zones (which never trigger motion).
+pub fn zone_specs_from_models(zones: &[zones::Model]) -> Vec<ZoneSpec> {
+    zones
+        .iter()
+        .filter(|z| !matches!(z.r#type, ZoneType::Inactive | ZoneType::Privacy))
+        .map(|z| ZoneSpec {
+            name: z.name.clone(),
+            coords: z.coords.clone(),
+            min_pixel_threshold: z.min_pixel_threshold,
+            max_pixel_threshold: z.max_pixel_threshold,
+        })
+        .collect()
+}
+
+/// Build the pipeline JSON document for one monitor.
+///
+/// * `source_url` — the capture RTSP URL (the monitor's `Path`).
+/// * `events_root` — directory the `store_event` stage writes clips under
+///   (the monitor's storage path, resolved from the Storage row by the caller).
+pub fn generate_pipeline(
+    monitor_id: u32,
+    source_url: &str,
+    zones: &[ZoneSpec],
+    cfg: &PipelineConfig,
+    events_root: &Path,
+) -> Value {
+    let mut detect_cfg = json!({
+        "model_path": cfg.model_path.to_string_lossy(),
+        "hw": cfg.detect_hw,
+        "input_size": cfg.detect_input_size,
+        "conf_threshold": cfg.detect_conf_threshold,
+        "roi_motion": true,
+    });
+    let zone_specs = translate_zones(zones);
+    if !zone_specs.is_empty() {
+        detect_cfg["zones"] = Value::Array(zone_specs);
+    }
+
+    // store_event is always present; output_mqtt only when a broker is set.
+    let mut detect_children = vec![json!({
+        "id": "record",
+        "kind": "store_event",
+        "cfg": {
+            "root": events_root.to_string_lossy(),
+            "monitor_id": monitor_id,
+            "trigger_types": ["detection"],
+            "pre_roll_sec": 5,
+            "post_roll_sec": 10,
+        },
+        "queue_depth": 120,
+    })];
+    if let Some((host, port)) = mqtt_host_port(cfg.mqtt_url.as_deref()) {
+        detect_children.push(json!({
+            "id": "notify",
+            "kind": "output_mqtt",
+            "cfg": { "host": host, "port": port, "base_topic": "zm-next" },
+            "queue_depth": 8,
+        }));
+    }
+
+    json!({
+        "name": format!("monitor_{monitor_id}"),
+        "root": true,
+        "plugins": [{
+            "id": "capture",
+            "kind": "capture_rtsp_multi",
+            "cfg": {
+                "streams": [{
+                    "stream_id": 0,
+                    "url": source_url,
+                    "transport": cfg.rtsp_transport,
+                    "max_retry_attempts": -1,
+                }],
+            },
+            "children": [{
+                "id": "detect",
+                "kind": "decode_detect",
+                "cfg": detect_cfg,
+                "queue_depth": 2,
+                "children": detect_children,
+            }],
+        }],
+    })
+}
+
+/// Serialize and write the pipeline for `monitor_id` to `dir`, returning the
+/// file path. Creates `dir` if it does not exist.
+pub fn write_pipeline_file(dir: &Path, monitor_id: u32, pipeline: &Value) -> io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!("monitor_{monitor_id}.json"));
+    let body = serde_json::to_vec_pretty(pipeline).map_err(io::Error::other)?;
+    std::fs::write(&path, body)?;
+    Ok(path)
+}
+
+/// Turn [`ZoneSpec`]s into detect-stage zone JSON, dropping zones whose polygon
+/// fails to parse.
+fn translate_zones(zones: &[ZoneSpec]) -> Vec<Value> {
+    zones
+        .iter()
+        .filter_map(|z| {
+            let points = parse_coords(&z.coords);
+            if points.is_empty() {
+                return None;
+            }
+            Some(json!({
+                "name": z.name,
+                "points": points,
+                "min_pixel_threshold": z.min_pixel_threshold,
+                "max_pixel_threshold": z.max_pixel_threshold,
+            }))
+        })
+        .collect()
+}
+
+/// Parse ZoneMinder's `Coords` string ("x1,y1 x2,y2 ...") into `[[x,y], ...]`.
+fn parse_coords(coords: &str) -> Vec<[i64; 2]> {
+    coords
+        .split_whitespace()
+        .filter_map(|pair| {
+            let (x, y) = pair.split_once(',')?;
+            Some([x.trim().parse().ok()?, y.trim().parse().ok()?])
+        })
+        .collect()
+}
+
+/// Split an `mqtt://host:port` (or `host:port`) URL into host + port.
+fn mqtt_host_port(url: Option<&str>) -> Option<(String, u16)> {
+    let url = url?;
+    let authority = url.strip_prefix("mqtt://").unwrap_or(url);
+    let authority = authority.split('/').next().unwrap_or(authority);
+    match authority.rsplit_once(':') {
+        Some((host, port)) => Some((host.to_string(), port.parse().ok()?)),
+        None => Some((authority.to_string(), 1883)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cfg() -> PipelineConfig {
+        PipelineConfig {
+            mqtt_url: None,
+            ..PipelineConfig::default()
+        }
+    }
+
+    #[test]
+    fn parse_coords_handles_polygon_and_garbage() {
+        assert_eq!(
+            parse_coords("0,0 640,0 640,480 0,480"),
+            vec![[0, 0], [640, 0], [640, 480], [0, 480]]
+        );
+        // Skips malformed pairs, keeps valid ones.
+        assert_eq!(parse_coords("10,20 bad 30,40"), vec![[10, 20], [30, 40]]);
+        assert!(parse_coords("").is_empty());
+    }
+
+    #[test]
+    fn mqtt_host_port_parses_forms() {
+        assert_eq!(
+            mqtt_host_port(Some("mqtt://broker:1884")),
+            Some(("broker".to_string(), 1884))
+        );
+        assert_eq!(
+            mqtt_host_port(Some("localhost")),
+            Some(("localhost".to_string(), 1883))
+        );
+        assert_eq!(mqtt_host_port(None), None);
+    }
+
+    #[test]
+    fn pipeline_has_capture_detect_store_chain() {
+        let cfg = test_cfg();
+        let zones = vec![ZoneSpec {
+            name: "Front".to_string(),
+            coords: "0,0 640,0 640,480 0,480".to_string(),
+            min_pixel_threshold: Some(25),
+            max_pixel_threshold: None,
+        }];
+        let p = generate_pipeline(
+            7,
+            "rtsp://admin:pw@cam:554/Streaming/Channels/101",
+            &zones,
+            &cfg,
+            Path::new("/var/lib/zm/events"),
+        );
+
+        assert_eq!(p["name"], "monitor_7");
+        assert_eq!(p["root"], true);
+        let capture = &p["plugins"][0];
+        assert_eq!(capture["kind"], "capture_rtsp_multi");
+        assert_eq!(
+            capture["cfg"]["streams"][0]["url"],
+            "rtsp://admin:pw@cam:554/Streaming/Channels/101"
+        );
+
+        let detect = &capture["children"][0];
+        assert_eq!(detect["kind"], "decode_detect");
+        // The active zone is translated onto the detect stage.
+        assert_eq!(detect["cfg"]["zones"][0]["name"], "Front");
+        assert_eq!(detect["cfg"]["zones"][0]["points"][1], json!([640, 0]));
+        assert_eq!(detect["cfg"]["zones"][0]["min_pixel_threshold"], 25);
+
+        let record = &detect["children"][0];
+        assert_eq!(record["kind"], "store_event");
+        assert_eq!(record["cfg"]["root"], "/var/lib/zm/events");
+        assert_eq!(record["cfg"]["monitor_id"], 7);
+        // No MQTT broker configured → no output_mqtt child.
+        assert_eq!(detect["children"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn mqtt_broker_adds_output_stage() {
+        let cfg = PipelineConfig {
+            mqtt_url: Some("mqtt://localhost:1883".to_string()),
+            ..PipelineConfig::default()
+        };
+        let p = generate_pipeline(1, "rtsp://cam/stream", &[], &cfg, Path::new("/events"));
+        let detect = &p["plugins"][0]["children"][0];
+        let children = detect["children"].as_array().unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[1]["kind"], "output_mqtt");
+        assert_eq!(children[1]["cfg"]["port"], 1883);
+        // No zones supplied → the detect cfg omits the zones key entirely.
+        assert!(detect["cfg"].get("zones").is_none());
+    }
+}

--- a/src/streaming/source/mod.rs
+++ b/src/streaming/source/mod.rs
@@ -12,8 +12,11 @@ pub use media::{
 // Re-export stream-socket reader types
 pub use stream_socket::{stream_socket_path, SocketEvent, SourceError, StreamSocketReader};
 
+// Re-export the monitor EVENT type for DB ingest consumers.
+pub use protocol::MonitorEvent;
+
 // Re-export router types
 pub use router::{
-    CachedKeyframe, MonitorSource, ReaderHealth, RouterConfig, RouterError, SourceRouter,
-    SourceStats, StreamInfo,
+    CachedKeyframe, MonitorEventEnvelope, MonitorSource, ReaderHealth, RouterConfig, RouterError,
+    SourceRouter, SourceStats, StreamInfo,
 };

--- a/src/streaming/source/protocol.rs
+++ b/src/streaming/source/protocol.rs
@@ -40,6 +40,9 @@ pub enum MessageType {
     Keyframe,
     Stats,
     Bye,
+    /// Monitor lifecycle / analysis event (see [`MonitorEvent`]). Carried on
+    /// [`StreamId::Monitor`]; payload is a u16 code plus a TLV tail.
+    Event,
 }
 
 impl MessageType {
@@ -50,6 +53,10 @@ impl MessageType {
             0x03 => Some(MessageType::Keyframe),
             0x04 => Some(MessageType::Stats),
             0x05 => Some(MessageType::Bye),
+            0x06 => Some(MessageType::Event),
+            // 0x10..=0x13 are the optional client→server control extension
+            // (Subscribe/Command/Response/Talkback); canonical consumers never
+            // send them and skip them on the wire like any other unknown type.
             _ => None,
         }
     }
@@ -59,6 +66,8 @@ impl MessageType {
 pub enum StreamId {
     Video,
     Audio,
+    /// Neither video nor audio: monitor lifecycle / analysis EVENT frames.
+    Monitor,
 }
 
 impl StreamId {
@@ -66,6 +75,7 @@ impl StreamId {
         match v {
             0 => Some(StreamId::Video),
             1 => Some(StreamId::Audio),
+            2 => Some(StreamId::Monitor),
             _ => None,
         }
     }
@@ -86,6 +96,33 @@ const TLV_CHANNELS: u8 = 0x08; // u32
 const TLV_PROFILE: u8 = 0x09; // u32
 const TLV_LEVEL: u8 = 0x0A; // u32
 
+// EVENT codes. Lifecycle codes are canonical (also emitted by stock zmc on the
+// `feature/stream-socket-events` branch); the 0x03xx range is zm-next's
+// additive analysis/AI extension. Unknown codes are surfaced verbatim, never
+// errored.
+pub const EVENT_SNAPSHOT: u16 = 0x0001; // current health+state, replayed on connect
+pub const EVENT_CONNECTION_FAILED: u16 = 0x0101;
+pub const EVENT_CONNECTION_RESTORED: u16 = 0x0102;
+pub const EVENT_PRIME_CAPTURE_FAILED: u16 = 0x0103;
+pub const EVENT_PRIME_CAPTURE_RESTORED: u16 = 0x0104;
+pub const EVENT_CAPTURE_FAILED: u16 = 0x0105;
+pub const EVENT_CAPTURE_RESUMED: u16 = 0x0106;
+pub const EVENT_STATE_CHANGED: u16 = 0x0201;
+// zm-next analysis/AI extension codes (reserved 0x03xx range):
+pub const EVENT_DETECTION: u16 = 0x0301; // motion / object detection
+pub const EVENT_DESCRIPTION: u16 = 0x0302; // VLM scene description
+pub const EVENT_RECORDING_SAVED: u16 = 0x0303; // a clip was written to storage
+
+// EVENT TLV tags
+const TLV_WALL_CLOCK_US: u8 = 0x01; // u64, unix-epoch microseconds
+const TLV_MESSAGE: u8 = 0x02; // utf8, human-readable detail
+const TLV_STATE_ID: u8 = 0x03; // u32, current monitor state
+const TLV_PREV_STATE_ID: u8 = 0x04; // u32, previous state (state_changed)
+const TLV_DETAIL: u8 = 0x05; // u32, errno / ffmpeg error code
+const TLV_STATE_NAME: u8 = 0x06; // utf8, "Idle"/"Alarm"/...
+const TLV_HEALTH_CODE: u8 = 0x07; // u16, active fault code in a snapshot (0 = healthy)
+const TLV_JSON_DETAIL: u8 = 0x10; // utf8 JSON, zm-next structured analysis/AI detail
+
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum ProtocolError {
     #[error("unsupported stream socket protocol version {0}")]
@@ -102,6 +139,9 @@ pub enum ProtocolError {
 
     #[error("payload too short for {0} message")]
     ShortPayload(&'static str),
+
+    #[error("truncated TLV in EVENT payload")]
+    TruncatedEventTlv,
 }
 
 /// A parsed message header. `msg_type` and `stream` are kept raw so unknown
@@ -214,6 +254,84 @@ pub fn parse_hello(data: &[u8]) -> Result<HelloInfo, ProtocolError> {
     Ok(info)
 }
 
+/// Decoded EVENT payload. A field is `Some`/non-empty only when its TLV tag
+/// was present on the wire; producers omit tags that do not apply to the code.
+/// `code` is always present (it is the fixed u16 prefix).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MonitorEvent {
+    /// One of the `EVENT_*` codes. Unknown codes are surfaced, not errored —
+    /// consumers map what they understand and ignore the rest.
+    pub code: u16,
+    /// Unix-epoch microseconds — the timestamp to surface for this event.
+    pub wall_clock_us: Option<u64>,
+    /// Human-readable detail.
+    pub message: Option<String>,
+    /// Current monitor state id.
+    pub state_id: Option<u32>,
+    /// Previous monitor state id (state_changed).
+    pub prev_state_id: Option<u32>,
+    /// errno / ffmpeg error code accompanying a fault.
+    pub detail: Option<u32>,
+    /// Current state name ("Idle"/"Alarm"/...).
+    pub state_name: Option<String>,
+    /// Active fault code in a snapshot (0 = healthy).
+    pub health_code: Option<u16>,
+    /// zm-next extension: structured analysis/AI detail as a UTF-8 JSON
+    /// document (detection object list, description text, recording metadata).
+    pub json_detail: Option<String>,
+}
+
+/// Parse an EVENT payload: a u16 `code` followed by a TLV tail of
+/// (u8 tag, u16 length, value). Unknown tags are skipped per the protocol
+/// spec, exactly like HELLO. Fails only when the fixed code or a TLV header
+/// runs past the end of the payload.
+pub fn parse_event(data: &[u8]) -> Result<MonitorEvent, ProtocolError> {
+    if data.len() < 2 {
+        return Err(ProtocolError::ShortPayload("EVENT"));
+    }
+    let mut ev = MonitorEvent {
+        code: u16::from_le_bytes([data[0], data[1]]),
+        ..MonitorEvent::default()
+    };
+
+    let mut i = 2usize;
+    while i < data.len() {
+        if i + 3 > data.len() {
+            return Err(ProtocolError::TruncatedEventTlv);
+        }
+        let tag = data[i];
+        let len = u16::from_le_bytes([data[i + 1], data[i + 2]]) as usize;
+        i += 3;
+        if i + len > data.len() {
+            return Err(ProtocolError::TruncatedEventTlv);
+        }
+        let value = &data[i..i + len];
+        i += len;
+
+        match tag {
+            TLV_WALL_CLOCK_US if len == 8 => {
+                ev.wall_clock_us = Some(read_u64(value, 0));
+            }
+            TLV_MESSAGE => ev.message = Some(String::from_utf8_lossy(value).into_owned()),
+            TLV_STATE_ID if len == 4 => ev.state_id = Some(read_u32(value, 0)),
+            TLV_PREV_STATE_ID if len == 4 => ev.prev_state_id = Some(read_u32(value, 0)),
+            TLV_DETAIL if len == 4 => ev.detail = Some(read_u32(value, 0)),
+            TLV_STATE_NAME => ev.state_name = Some(String::from_utf8_lossy(value).into_owned()),
+            TLV_HEALTH_CODE if len == 2 => {
+                ev.health_code = Some(u16::from_le_bytes([value[0], value[1]]));
+            }
+            TLV_JSON_DETAIL => ev.json_detail = Some(String::from_utf8_lossy(value).into_owned()),
+            // Unknown tag, or a known tag with an unexpected length: skip.
+            _ => {}
+        }
+    }
+    Ok(ev)
+}
+
+fn read_u64(buf: &[u8], at: usize) -> u64 {
+    u64::from_le_bytes(buf[at..at + 8].try_into().expect("8 bytes"))
+}
+
 /// Parse a STATS payload: u64 messages sent, u64 messages dropped for this
 /// consumer.
 pub fn parse_stats(data: &[u8]) -> Result<(u64, u64), ProtocolError> {
@@ -286,6 +404,21 @@ pub(crate) mod test_encode {
 
     pub fn tlv_u32(tag: u8, value: u32) -> Vec<u8> {
         tlv(tag, &value.to_le_bytes())
+    }
+
+    pub fn tlv_u64(tag: u8, value: u64) -> Vec<u8> {
+        tlv(tag, &value.to_le_bytes())
+    }
+
+    pub fn tlv_u16(tag: u8, value: u16) -> Vec<u8> {
+        tlv(tag, &value.to_le_bytes())
+    }
+
+    /// Build an EVENT payload: the u16 code followed by a pre-built TLV tail.
+    pub fn event_payload(code: u16, tlv_tail: &[u8]) -> Vec<u8> {
+        let mut p = code.to_le_bytes().to_vec();
+        p.extend_from_slice(tlv_tail);
+        p
     }
 
     /// Build a HELLO payload with a codec id and optional extradata.
@@ -372,9 +505,14 @@ mod tests {
         assert_eq!(MessageType::from_u8(0x03), Some(MessageType::Keyframe));
         assert_eq!(MessageType::from_u8(0x04), Some(MessageType::Stats));
         assert_eq!(MessageType::from_u8(0x05), Some(MessageType::Bye));
+        assert_eq!(MessageType::from_u8(0x06), Some(MessageType::Event));
         assert_eq!(MessageType::from_u8(0x77), None);
+        // The client→server control extension is "unknown" to canonical
+        // consumers and must skip, not resolve.
+        assert_eq!(MessageType::from_u8(0x10), None);
         assert_eq!(StreamId::from_u8(1), Some(StreamId::Audio));
-        assert_eq!(StreamId::from_u8(2), None);
+        assert_eq!(StreamId::from_u8(2), Some(StreamId::Monitor));
+        assert_eq!(StreamId::from_u8(3), None);
     }
 
     #[test]
@@ -431,6 +569,76 @@ mod tests {
         );
         // Empty payload.
         assert_eq!(parse_hello(&[]), Err(ProtocolError::MissingCodecId));
+    }
+
+    #[test]
+    fn event_parses_lifecycle_state_change() {
+        // state_changed: wall clock + state ids + names.
+        let mut tail = tlv_u64(0x01, 1_700_000_000_000_000);
+        tail.extend_from_slice(&tlv_u32(0x03, 2));
+        tail.extend_from_slice(&tlv_u32(0x04, 1));
+        tail.extend_from_slice(&tlv(0x06, b"Alarm"));
+        tail.extend_from_slice(&tlv(0x02, b"motion in zone 1"));
+        let payload = event_payload(EVENT_STATE_CHANGED, &tail);
+
+        let ev = parse_event(&payload).unwrap();
+        assert_eq!(ev.code, EVENT_STATE_CHANGED);
+        assert_eq!(ev.wall_clock_us, Some(1_700_000_000_000_000));
+        assert_eq!(ev.state_id, Some(2));
+        assert_eq!(ev.prev_state_id, Some(1));
+        assert_eq!(ev.state_name.as_deref(), Some("Alarm"));
+        assert_eq!(ev.message.as_deref(), Some("motion in zone 1"));
+        assert_eq!(ev.health_code, None);
+        assert_eq!(ev.json_detail, None);
+    }
+
+    #[test]
+    fn event_parses_zmnext_detection_json() {
+        let json = r#"{"objects":[{"label":"person","confidence":0.91}],"frame_pts_us":42}"#;
+        let mut tail = tlv_u64(0x01, 1_700_000_000_000_000);
+        tail.extend_from_slice(&tlv(0x10, json.as_bytes()));
+        let payload = event_payload(EVENT_DETECTION, &tail);
+
+        let ev = parse_event(&payload).unwrap();
+        assert_eq!(ev.code, EVENT_DETECTION);
+        assert_eq!(ev.json_detail.as_deref(), Some(json));
+        assert_eq!(ev.wall_clock_us, Some(1_700_000_000_000_000));
+    }
+
+    #[test]
+    fn event_parses_snapshot_health_code() {
+        let tail = tlv_u16(0x07, 0x0105); // capture_failed health code, healthy=0
+        let payload = event_payload(EVENT_SNAPSHOT, &tail);
+        let ev = parse_event(&payload).unwrap();
+        assert_eq!(ev.code, EVENT_SNAPSHOT);
+        assert_eq!(ev.health_code, Some(0x0105));
+    }
+
+    #[test]
+    fn event_skips_unknown_tags_and_surfaces_unknown_codes() {
+        // An unknown code (future lifecycle event) with an unknown tag mixed
+        // in among known ones — both must be tolerated.
+        let mut tail = tlv(0x7F, &[1, 2, 3]); // unknown tag
+        tail.extend_from_slice(&tlv(0x02, b"hi"));
+        let payload = event_payload(0x09FF, &tail); // unknown code
+        let ev = parse_event(&payload).unwrap();
+        assert_eq!(ev.code, 0x09FF);
+        assert_eq!(ev.message.as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn event_rejects_short_code_and_truncated_tlv() {
+        // Fewer than the 2 fixed code bytes.
+        assert_eq!(
+            parse_event(&[0x01]),
+            Err(ProtocolError::ShortPayload("EVENT"))
+        );
+        // Code present, TLV header claims more value than remains.
+        let mut payload = 0x0301u16.to_le_bytes().to_vec();
+        payload.extend_from_slice(&[0x02, 0xFF, 0x00, 0xAA]); // claims 255 bytes
+        assert_eq!(parse_event(&payload), Err(ProtocolError::TruncatedEventTlv));
+        // Empty payload still has no code.
+        assert_eq!(parse_event(&[]), Err(ProtocolError::ShortPayload("EVENT")));
     }
 
     #[test]

--- a/src/streaming/source/protocol.rs
+++ b/src/streaming/source/protocol.rs
@@ -112,6 +112,13 @@ pub const EVENT_STATE_CHANGED: u16 = 0x0201;
 pub const EVENT_DETECTION: u16 = 0x0301; // motion / object detection
 pub const EVENT_DESCRIPTION: u16 = 0x0302; // VLM scene description
 pub const EVENT_RECORDING_SAVED: u16 = 0x0303; // a clip was written to storage
+pub const EVENT_RECORDING_OPENING: u16 = 0x0304; // a clip segment opened; awaits an event-id assignment
+
+/// Client→server control message type for the id-assignment handshake (the
+/// `0x11 Command` of zm-next's control extension). zm-api is the client; the
+/// canonical media producer (zmc) ignores inbound bytes, while zm-next's worker
+/// consumes this to learn the event id + target path for a recording segment.
+pub const MSG_TYPE_COMMAND: u8 = 0x11;
 
 // EVENT TLV tags
 const TLV_WALL_CLOCK_US: u8 = 0x01; // u64, unix-epoch microseconds
@@ -330,6 +337,24 @@ pub fn parse_event(data: &[u8]) -> Result<MonitorEvent, ProtocolError> {
 
 fn read_u64(buf: &[u8], at: usize) -> u64 {
     u64::from_le_bytes(buf[at..at + 8].try_into().expect("8 bytes"))
+}
+
+/// Serialize a client→server control message (header + raw payload) for
+/// sending back up the stream socket. Control messages ride the Monitor stream
+/// with their own sequence counter; `generation` and `pts` are unused (0).
+/// Used for the `0x11 Command` id-assignment reply, whose payload is UTF-8 JSON.
+pub fn build_control_message(msg_type: u8, sequence: u32, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_SIZE + payload.len());
+    out.extend_from_slice(&(HEADER_LENGTH_BYTES + payload.len() as u32).to_le_bytes());
+    out.push(PROTOCOL_VERSION);
+    out.push(msg_type);
+    out.push(StreamId::Monitor as u8); // 2 — control rides the monitor stream
+    out.push(0); // flags
+    out.extend_from_slice(&sequence.to_le_bytes());
+    out.extend_from_slice(&0u32.to_le_bytes()); // generation (unused)
+    out.extend_from_slice(&0u64.to_le_bytes()); // pts_us (unused)
+    out.extend_from_slice(payload);
+    out
 }
 
 /// Parse a STATS payload: u64 messages sent, u64 messages dropped for this
@@ -639,6 +664,20 @@ mod tests {
         assert_eq!(parse_event(&payload), Err(ProtocolError::TruncatedEventTlv));
         // Empty payload still has no code.
         assert_eq!(parse_event(&[]), Err(ProtocolError::ShortPayload("EVENT")));
+    }
+
+    #[test]
+    fn control_message_round_trips_through_header() {
+        let json = br#"{"cmd":"assign_recording","event_id":512}"#;
+        let msg = build_control_message(MSG_TYPE_COMMAND, 3, json);
+        let header = parse_header(msg[..HEADER_SIZE].try_into().unwrap()).unwrap();
+        assert_eq!(header.msg_type, MSG_TYPE_COMMAND);
+        assert_eq!(header.stream, 2); // Monitor
+        assert_eq!(header.sequence, 3);
+        assert_eq!(header.payload_len, json.len());
+        assert_eq!(&msg[HEADER_SIZE..], json);
+        // The control type is not a media/parse type — consumers skip it.
+        assert_eq!(MessageType::from_u8(header.msg_type), None);
     }
 
     #[test]

--- a/src/streaming/source/router.rs
+++ b/src/streaming/source/router.rs
@@ -4,10 +4,12 @@
 //! serves all output protocols (WebRTC, HLS). Manages lazy initialization of
 //! monitor sources; one socket connection carries both video and audio.
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{broadcast, mpsc, watch, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
@@ -16,17 +18,50 @@ use super::media::{
     extract_profile_level_id, h264_nal_type, h265_nal_type, AudioCodec, AudioPacket, VideoCodec,
     VideoPacket,
 };
-use super::protocol::MonitorEvent;
+use super::protocol::{self, MonitorEvent};
 use super::stream_socket::{stream_socket_path, SocketEvent, SourceError, StreamSocketReader};
 use crate::configure::streaming::ZoneMinderConfig;
 
 /// A monitor EVENT decoded off a stream socket, tagged with its monitor, ready
 /// for DB ingest. The reader task forwards these to the router's event sink
 /// (when one is registered); media flows unaffected.
+///
+/// `reply` lets the ingest side answer the worker on the *same* connection —
+/// the id-assignment handshake replies to a `recording_opening` EVENT with the
+/// allocated event id and target path.
 #[derive(Debug, Clone)]
 pub struct MonitorEventEnvelope {
     pub monitor_id: u32,
     pub event: MonitorEvent,
+    pub reply: ControlReply,
+}
+
+/// Cloneable handle for sending client→server control messages on one monitor's
+/// stream-socket connection. Messages are queued to the reader task, which owns
+/// the connection's write half and flushes them. Best-effort by design: if the
+/// connection has closed (queue full or receiver gone) the send is dropped, so
+/// ingest never blocks or stalls on a dead worker.
+#[derive(Debug, Clone)]
+pub struct ControlReply {
+    tx: mpsc::Sender<Vec<u8>>,
+    seq: Arc<AtomicU32>,
+}
+
+impl ControlReply {
+    fn new(tx: mpsc::Sender<Vec<u8>>) -> Self {
+        Self {
+            tx,
+            seq: Arc::new(AtomicU32::new(0)),
+        }
+    }
+
+    /// Queue a `0x11 Command` with a JSON payload for the worker. Returns
+    /// whether it was queued (false ⇒ connection gone / queue full).
+    pub fn send_command_json(&self, json: &str) -> bool {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let msg = protocol::build_control_message(protocol::MSG_TYPE_COMMAND, seq, json.as_bytes());
+        self.tx.try_send(msg).is_ok()
+    }
 }
 
 /// Default broadcast channel capacity for source packets
@@ -563,6 +598,15 @@ impl SourceRouter {
                     }
                 }
 
+                // Per-connection control channel for the id-assignment
+                // handshake: ingest queues replies here and the reader task
+                // writes them to this connection's write half. Recreated each
+                // reconnect; the old channel + writer drop with the old socket.
+                let mut writer = reader.take_writer();
+                let (cmd_tx, mut cmd_rx) = mpsc::channel::<Vec<u8>>(8);
+                let control_reply = ControlReply::new(cmd_tx.clone());
+                let _cmd_keepalive = cmd_tx; // hold the channel open for this connection
+
                 // Topology of this connection. zmc sends every stream's HELLO
                 // before any media, so the first media event confirms the
                 // handshake is complete and the audio answer is final.
@@ -571,9 +615,23 @@ impl SourceRouter {
                 let mut announced = false;
 
                 // Inner loop: read events until the socket closes or an
-                // unrecoverable error occurs
+                // unrecoverable error occurs. `select!` also drains queued
+                // control replies, writing them on this connection (biased so a
+                // pending id-assignment is flushed before the next read).
                 loop {
-                    match reader.next_event().await {
+                    tokio::select! {
+                        biased;
+                        Some(bytes) = cmd_rx.recv() => {
+                            if let Some(w) = writer.as_mut() {
+                                if let Err(e) = w.write_all(&bytes).await {
+                                    warn!("Monitor {}: control write failed: {}", monitor_id, e);
+                                } else {
+                                    let _ = w.flush().await;
+                                }
+                            }
+                        }
+                        result = reader.next_event() => {
+                    match result {
                         Ok(SocketEvent::VideoParams { codec }) => {
                             video_codec = codec;
                             let mut codec_guard = source_for_task.codec.write().await;
@@ -631,10 +689,13 @@ impl SourceRouter {
                             // Forward to DB ingest. `try_send` keeps the media
                             // reader non-blocking: if ingest is backed up or
                             // absent we drop the event rather than stall video.
+                            // `reply` lets ingest answer on this connection.
                             if let Some(sink) = &event_sink {
-                                if let Err(e) =
-                                    sink.try_send(MonitorEventEnvelope { monitor_id, event })
-                                {
+                                if let Err(e) = sink.try_send(MonitorEventEnvelope {
+                                    monitor_id,
+                                    event,
+                                    reply: control_reply.clone(),
+                                }) {
                                     warn!(
                                         "Monitor {}: dropping EVENT, ingest sink unavailable: {}",
                                         monitor_id, e
@@ -663,6 +724,8 @@ impl SourceRouter {
                             tokio::time::sleep(Duration::from_millis(config.reconnect_delay_ms))
                                 .await;
                             break; // Break inner loop to reconnect with fresh state
+                        }
+                    }
                         }
                     }
                 }
@@ -1196,6 +1259,77 @@ mod tests {
         assert_eq!(ck.profile_level_id, "4d0033");
 
         let _ = router.stop_reader(8).await;
+        server.abort();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The id-assignment handshake round-trips over a real socket: the worker
+    /// emits a recording_opening EVENT, the consumer replies via the EVENT
+    /// envelope, and the reply lands back on the same connection as a 0x11
+    /// Command — exercising the reader's write half and ControlReply encoding.
+    #[tokio::test]
+    async fn test_control_reply_round_trips_to_worker() {
+        use super::super::protocol::{
+            parse_header, EVENT_RECORDING_OPENING, HEADER_SIZE, MSG_TYPE_COMMAND,
+        };
+        use super::super::stream_socket::test_support::spawn_fake_zmc_capturing;
+
+        let dir = test_sock_dir("router_control");
+        // Script: video HELLO, then a recording_opening EVENT on the monitor
+        // stream carrying a clip_token.
+        let mut script = encode_message(
+            0x01,
+            0,
+            0,
+            0,
+            0,
+            0,
+            &hello_payload(h264_codec_id(), &h264_extradata()),
+        );
+        let opening = event_payload(
+            EVENT_RECORDING_OPENING,
+            &tlv(0x10, br#"{"clip_token":"tok-1"}"#),
+        );
+        script.extend_from_slice(&encode_message(0x06, 2, 0, 0, 0, 0, &opening));
+        let (server, mut captured) = spawn_fake_zmc_capturing(dir.join("stream_20.sock"), script);
+
+        let mut router = SourceRouter::from_zoneminder_config(test_zm_config(&dir));
+        let (ev_tx, mut ev_rx) = mpsc::channel(8);
+        router.set_event_sink(ev_tx);
+        router.get_source(20).await.expect("get_source");
+
+        // Receive the EVENT envelope and reply on its connection.
+        let env = tokio::time::timeout(Duration::from_secs(5), ev_rx.recv())
+            .await
+            .expect("event within 5s")
+            .expect("envelope");
+        assert_eq!(env.monitor_id, 20);
+        assert_eq!(env.event.code, EVENT_RECORDING_OPENING);
+        assert!(env
+            .reply
+            .send_command_json(r#"{"cmd":"assign_recording","event_id":42}"#));
+
+        // The worker reads the reply: a 0x11 Command framing our JSON.
+        let mut buf = Vec::new();
+        for _ in 0..50 {
+            if let Ok(Some(chunk)) =
+                tokio::time::timeout(Duration::from_millis(200), captured.recv()).await
+            {
+                buf.extend_from_slice(&chunk);
+                if buf.len() >= HEADER_SIZE {
+                    break;
+                }
+            }
+        }
+        let header = parse_header(buf[..HEADER_SIZE].try_into().unwrap()).expect("valid header");
+        assert_eq!(header.msg_type, MSG_TYPE_COMMAND);
+        assert_eq!(header.stream, 2); // Monitor
+        let payload = &buf[HEADER_SIZE..HEADER_SIZE + header.payload_len];
+        let json: serde_json::Value = serde_json::from_slice(payload).expect("json payload");
+        assert_eq!(json["cmd"], "assign_recording");
+        assert_eq!(json["event_id"], 42);
+
+        let _ = router.stop_reader(20).await;
         server.abort();
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/streaming/source/router.rs
+++ b/src/streaming/source/router.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dashmap::DashMap;
-use tokio::sync::{broadcast, watch, RwLock};
+use tokio::sync::{broadcast, mpsc, watch, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
@@ -16,8 +16,18 @@ use super::media::{
     extract_profile_level_id, h264_nal_type, h265_nal_type, AudioCodec, AudioPacket, VideoCodec,
     VideoPacket,
 };
+use super::protocol::MonitorEvent;
 use super::stream_socket::{stream_socket_path, SocketEvent, SourceError, StreamSocketReader};
 use crate::configure::streaming::ZoneMinderConfig;
+
+/// A monitor EVENT decoded off a stream socket, tagged with its monitor, ready
+/// for DB ingest. The reader task forwards these to the router's event sink
+/// (when one is registered); media flows unaffected.
+#[derive(Debug, Clone)]
+pub struct MonitorEventEnvelope {
+    pub monitor_id: u32,
+    pub event: MonitorEvent,
+}
 
 /// Default broadcast channel capacity for source packets
 const DEFAULT_SOURCE_CAPACITY: usize = 100;
@@ -375,6 +385,11 @@ pub struct SourceRouter {
     active_sources: DashMap<u32, Arc<MonitorSource>>,
     /// Configuration
     config: RouterConfig,
+    /// Optional sink for monitor EVENTs decoded off the stream sockets. When
+    /// `Some`, each reader task forwards `MonitorEventEnvelope`s here (via
+    /// `try_send`, so a slow/backed-up ingest never stalls the media reader).
+    /// `None` means events are simply not ingested (e.g. tests, or DB absent).
+    event_sink: Option<mpsc::Sender<MonitorEventEnvelope>>,
 }
 
 impl SourceRouter {
@@ -388,7 +403,17 @@ impl SourceRouter {
         Self {
             active_sources: DashMap::new(),
             config,
+            event_sink: None,
         }
+    }
+
+    /// Register a sink to receive monitor EVENTs decoded off the stream
+    /// sockets. Call before any reader starts (i.e. before wrapping the router
+    /// in an `Arc` / handing it to the coordinator). Readers started after this
+    /// forward events to `sink`; without a sink, EVENTs are dropped after
+    /// decoding.
+    pub fn set_event_sink(&mut self, sink: mpsc::Sender<MonitorEventEnvelope>) {
+        self.event_sink = Some(sink);
     }
 
     /// Create a source router from ZoneMinder configuration
@@ -494,6 +519,7 @@ impl SourceRouter {
         let health_tx = source.reader_health_tx.clone();
         let stream_info_tx = source.stream_info_tx.clone();
         let keyframe_cache_tx = source.keyframe_cache_tx.clone();
+        let event_sink = self.event_sink.clone();
 
         let handle = tokio::spawn(async move {
             info!(
@@ -600,6 +626,21 @@ impl SourceRouter {
                             audio_packets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             // No receivers is fine — nobody listening.
                             let _ = audio_tx.send(packet);
+                        }
+                        Ok(SocketEvent::MonitorEvent(event)) => {
+                            // Forward to DB ingest. `try_send` keeps the media
+                            // reader non-blocking: if ingest is backed up or
+                            // absent we drop the event rather than stall video.
+                            if let Some(sink) = &event_sink {
+                                if let Err(e) =
+                                    sink.try_send(MonitorEventEnvelope { monitor_id, event })
+                                {
+                                    warn!(
+                                        "Monitor {}: dropping EVENT, ingest sink unavailable: {}",
+                                        monitor_id, e
+                                    );
+                                }
+                            }
                         }
                         Err(SourceError::Timeout { .. }) => {
                             // Expected when no media is flowing (idle camera);

--- a/src/streaming/source/stream_socket.rs
+++ b/src/streaming/source/stream_socket.rs
@@ -40,7 +40,7 @@ use super::media::{
     AdtsWrapper, AudioCodec, AudioPacket, VideoCodec, VideoPacket,
 };
 use super::protocol::{
-    self, Header, MessageType, ProtocolError, StreamId, FLAG_KEYFRAME, HEADER_SIZE,
+    self, Header, MessageType, MonitorEvent, ProtocolError, StreamId, FLAG_KEYFRAME, HEADER_SIZE,
 };
 use crate::configure::streaming::ZoneMinderConfig;
 
@@ -78,6 +78,10 @@ pub enum SocketEvent {
     Video(VideoPacket),
     /// One audio frame.
     Audio(AudioPacket),
+    /// A monitor lifecycle / analysis EVENT (zm-next or stock zmc). Carries no
+    /// media; routed to DB ingest rather than the media sinks. EVENTs use their
+    /// own per-monitor sequence counter, independent of the media streams.
+    MonitorEvent(MonitorEvent),
 }
 
 /// The documented-convention socket path for a monitor:
@@ -242,6 +246,22 @@ impl StreamSocketReader {
             );
             return Ok(());
         };
+
+        // EVENT frames ride the Monitor stream and carry no media; handle them
+        // before resolving a media stream id. A malformed EVENT is skipped (not
+        // fatal): the header already framed the payload, so one bad event does
+        // not desync the byte stream, and media must keep flowing.
+        if msg_type == MessageType::Event {
+            match protocol::parse_event(&payload) {
+                Ok(ev) => self.pending.push_back(SocketEvent::MonitorEvent(ev)),
+                Err(e) => debug!(
+                    "Monitor {}: skipping malformed EVENT payload: {e}",
+                    self.monitor_id
+                ),
+            }
+            return Ok(());
+        }
+
         let Some(stream_id) = StreamId::from_u8(header.stream) else {
             debug!(
                 "Monitor {}: skipping unknown stream id {}",
@@ -249,12 +269,22 @@ impl StreamSocketReader {
             );
             return Ok(());
         };
+        // Media / HELLO on the Monitor stream is meaningless — only EVENT is
+        // valid there. Skip rather than misinterpret it as video/audio.
+        if stream_id == StreamId::Monitor {
+            debug!(
+                "Monitor {}: skipping {:?} on the monitor stream",
+                self.monitor_id, msg_type
+            );
+            return Ok(());
+        }
 
         match msg_type {
             MessageType::Hello => self.handle_hello(stream_id, header, &payload)?,
             MessageType::Media | MessageType::Keyframe => {
                 self.handle_media(stream_id, header, payload)
             }
+            MessageType::Event => unreachable!("EVENT handled above"),
             MessageType::Stats => {
                 if let Ok((sent, dropped)) = protocol::parse_stats(&payload) {
                     if dropped > self.last_reported_drops {
@@ -361,6 +391,8 @@ impl StreamSocketReader {
                 );
                 self.pending.push_back(SocketEvent::AudioParams { codec });
             }
+            // Guarded out in handle_message; only video/audio HELLOs reach here.
+            StreamId::Monitor => unreachable!("monitor stream has no HELLO"),
         }
         Ok(())
     }
@@ -371,6 +403,7 @@ impl StreamSocketReader {
         let next_seq = match stream_id {
             StreamId::Video => &mut self.video.next_sequence,
             StreamId::Audio => &mut self.audio.next_sequence,
+            StreamId::Monitor => unreachable!("monitor stream carries no media"),
         };
         if let Some(expected) = *next_seq {
             if header.sequence != expected {
@@ -443,6 +476,7 @@ impl StreamSocketReader {
                     codec,
                 }));
             }
+            StreamId::Monitor => unreachable!("monitor stream carries no media"),
         }
     }
 }
@@ -511,6 +545,7 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::super::protocol::test_encode::*;
+    use super::super::protocol::{EVENT_DETECTION, EVENT_SNAPSHOT};
     use super::test_support::*;
     use super::*;
 
@@ -846,7 +881,7 @@ mod tests {
         ));
         script.extend_from_slice(&encode_message(0x04, 0, 0, 0, 0, 0, &stats_payload));
         script.extend_from_slice(&encode_message(0x7E, 0, 0, 0, 0, 0, &[1, 2, 3])); // unknown type
-        script.extend_from_slice(&encode_message(0x02, 2, 0, 0, 0, 0, &[4, 5])); // unknown stream
+        script.extend_from_slice(&encode_message(0x02, 3, 0, 0, 0, 0, &[4, 5])); // unknown stream id
         script.extend_from_slice(&encode_message(
             0x02,
             0,
@@ -864,6 +899,69 @@ mod tests {
         // STATS / unknown messages produce no events; media still flows.
         let events = collect_events(&mut reader, 4).await;
         assert!(matches!(events[0], SocketEvent::VideoParams { .. }));
+        assert!(matches!(events[3], SocketEvent::Video(_)));
+
+        server.abort();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn monitor_events_are_surfaced_between_media() {
+        let dir = test_sock_dir("events");
+        let sock = dir.join("stream_10.sock");
+
+        // HELLO, a snapshot EVENT replayed on connect, a detection EVENT, then
+        // a keyframe — media and events interleave on the one connection.
+        let snapshot = event_payload(EVENT_SNAPSHOT, &tlv_u16(0x07, 0));
+        let detection_json = r#"{"objects":[{"label":"car","confidence":0.8}]}"#;
+        let mut det_tail = tlv_u64(0x01, 1_700_000_000_000_000);
+        det_tail.extend_from_slice(&tlv(0x10, detection_json.as_bytes()));
+        let detection = event_payload(EVENT_DETECTION, &det_tail);
+
+        let mut script = Vec::new();
+        script.extend_from_slice(&encode_message(
+            0x01,
+            0,
+            0,
+            0,
+            0,
+            0,
+            &hello_payload(h264_codec_id(), &extradata()),
+        ));
+        // EVENT: type 0x06 on the monitor stream (id 2), own sequence counter.
+        script.extend_from_slice(&encode_message(0x06, 2, 0, 0, 0, 0, &snapshot));
+        script.extend_from_slice(&encode_message(0x06, 2, 0, 1, 0, 0, &detection));
+        script.extend_from_slice(&encode_message(
+            0x03,
+            0,
+            FLAG_KEYFRAME,
+            5,
+            0,
+            9_000_000,
+            &idr_au(),
+        ));
+
+        let server = spawn_fake_zmc(sock, script, false);
+        let mut reader = StreamSocketReader::new(10, test_config(&dir));
+        reader.connect().await.expect("connect");
+
+        // VideoParams, snapshot event, detection event, then 3 keyframe NALs.
+        let events = collect_events(&mut reader, 6).await;
+        assert!(matches!(events[0], SocketEvent::VideoParams { .. }));
+
+        let SocketEvent::MonitorEvent(snap) = &events[1] else {
+            panic!("expected snapshot MonitorEvent, got {:?}", events[1]);
+        };
+        assert_eq!(snap.code, EVENT_SNAPSHOT);
+        assert_eq!(snap.health_code, Some(0));
+
+        let SocketEvent::MonitorEvent(det) = &events[2] else {
+            panic!("expected detection MonitorEvent, got {:?}", events[2]);
+        };
+        assert_eq!(det.code, EVENT_DETECTION);
+        assert_eq!(det.json_detail.as_deref(), Some(detection_json));
+
+        // Media still flows after the events.
         assert!(matches!(events[3], SocketEvent::Video(_)));
 
         server.abort();

--- a/src/streaming/source/stream_socket.rs
+++ b/src/streaming/source/stream_socket.rs
@@ -32,6 +32,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use tokio::io::AsyncReadExt;
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
 use tracing::{debug, info, warn};
 
@@ -115,7 +116,12 @@ pub struct StreamSocketReader {
     monitor_id: u32,
     path: PathBuf,
     config: ZoneMinderConfig,
-    stream: Option<UnixStream>,
+    /// Read half of the connection. The write half ([`Self::take_writer`]) is
+    /// handed to the router task so it can send control replies (the
+    /// id-assignment handshake) on the same connection without contending with
+    /// the read loop for `&mut self`.
+    read: Option<OwnedReadHalf>,
+    write: Option<OwnedWriteHalf>,
     /// Accumulation buffer of raw socket bytes awaiting a complete message.
     buf: Vec<u8>,
     /// Events decoded from messages, awaiting emission (one message can
@@ -139,7 +145,8 @@ impl StreamSocketReader {
             monitor_id,
             path,
             config,
-            stream: None,
+            read: None,
+            write: None,
             buf: Vec::with_capacity(64 * 1024),
             pending: VecDeque::new(),
             video: VideoState::default(),
@@ -155,6 +162,14 @@ impl StreamSocketReader {
 
     pub fn socket_path(&self) -> &Path {
         &self.path
+    }
+
+    /// Take the connection's write half for sending control replies. Available
+    /// after [`Self::connect`]; returns `None` if already taken or not
+    /// connected. The router task owns it for the connection's lifetime and
+    /// drops it on reconnect (a fresh `connect` produces a new write half).
+    pub fn take_writer(&mut self) -> Option<OwnedWriteHalf> {
+        self.write.take()
     }
 
     /// Whether zmc has created the monitor's socket (it appears when zmc
@@ -179,7 +194,9 @@ impl StreamSocketReader {
         );
 
         let stream = UnixStream::connect(&self.path).await?;
-        self.stream = Some(stream);
+        let (read, write) = stream.into_split();
+        self.read = Some(read);
+        self.write = Some(write);
         self.buf.clear();
         self.pending.clear();
         self.video = VideoState::default();
@@ -229,8 +246,8 @@ impl StreamSocketReader {
 
             // 3. Need more bytes. `read_buf` appends to the buffer and is
             //    cancel-safe: if the caller's timeout fires, no data is lost.
-            let stream = self.stream.as_mut().ok_or(SourceError::NotConnected)?;
-            let n = stream.read_buf(&mut self.buf).await?;
+            let read = self.read.as_mut().ok_or(SourceError::NotConnected)?;
+            let n = read.read_buf(&mut self.buf).await?;
             if n == 0 {
                 return Err(SourceError::Closed);
             }
@@ -532,6 +549,42 @@ pub(crate) mod test_support {
                 });
             }
         })
+    }
+
+    /// Like [`spawn_fake_zmc`] but captures bytes the client writes back (the
+    /// control-channel replies), forwarding each read chunk on the returned
+    /// channel. Holds the connection open. Used to assert the id-assignment
+    /// handshake reaches the worker.
+    pub fn spawn_fake_zmc_capturing(
+        path: PathBuf,
+        script: Vec<u8>,
+    ) -> (
+        tokio::task::JoinHandle<()>,
+        tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let listener = UnixListener::bind(&path).expect("bind fake zmc socket");
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let script = script.clone();
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let _ = stream.write_all(&script).await;
+                    use tokio::io::AsyncReadExt;
+                    let mut buf = [0u8; 4096];
+                    while let Ok(n) = stream.read(&mut buf).await {
+                        if n == 0 {
+                            break;
+                        }
+                        let _ = tx.send(buf[..n].to_vec());
+                    }
+                });
+            }
+        });
+        (handle, rx)
     }
 
     /// A temp dir for a test's socket, cleaned by the caller.


### PR DESCRIPTION
Wire zm-api to orchestrate **zm-next** (`zm-core`) over the existing per-monitor stream-socket protocol. Off by default (`[zmnext].enabled`), reversible per camera; **zero behaviour change until enabled**.

## What's here

| Task | Area | Where |
|------|------|-------|
| 1 | EVENT (0x06) + `Monitor` stream parsing | `streaming/source/protocol.rs`, `stream_socket.rs` |
| 1 | Router → ingest sink | `streaming/source/router.rs` |
| 5 | EVENT → Events/Frames ingest | `service/zmnext/{detail,ingest}.rs` |
| 2 | Daemon spawns/supervises the worker | `daemon/manager.rs` |
| 3 | Pipeline JSON generator | `service/zmnext/pipeline.rs` |
| 4 | Per-monitor `UseZmNext` flag (graceful) | `repo/monitors.rs::use_zmnext` |
| — | Event-id assignment handshake | protocol `0x11`/`0x0304`, reader write-half, router `ControlReply`, ingest |
| — | Config + wiring + runbook | `configure/zmnext.rs`, `server/state.rs`, `docs/ZMNEXT_TASKS.md` |

## Design highlights

- **Media path untouched.** EVENT (0x06) on the new `Monitor` stream routes to ingest; WebRTC/HLS/MSE consume only Video/Audio as before. Unknown types/tags skip per the additive protocol.
- **Event-id assignment handshake.** zm-api owns the ZoneMinder event id end to end and hands it (plus the exact Medium-scheme path) to `store_event` at clip-open via a `0x11 Command`, so clips land natively in ZM's tree — **no schema change, no file relocation**. `recording_saved` finalizes by the echoed `event_id`.
- **`UseZmNext` flag is graceful.** Read via an isolated query that degrades to `false` (legacy) on a missing column, so this code is inert until the ZoneMinder fork ships the column — and activates automatically once it exists. The `monitors` SeaORM entity is deliberately **not** widened.
- **Daemon integration** reuses the existing `ManagedProcess` supervision (SIGTERM stop, backoff, watchdog, reconcile); "reload" = regenerate pipeline JSON + restart. Flipping the flag swaps daemons cleanly.

## Tests / gates

`cargo fmt` clean · `cargo clippy --all-targets --all-features -D warnings` clean · **572 lib tests pass** (incl. EVENT parsing, the control round-trip over a real socket, pipeline generation, ingest helpers).

## Cross-repo coordination (not in this PR)

1. **`Monitors.UseZmNext TINYINT NOT NULL DEFAULT 0`** — ZoneMinder fork migration. Until it lands, everything stays legacy.
2. **`store_event` handshake** — zm-next must emit `recording_opening`, consume `assign_recording` (stage-then-rename), and echo `event_id` in `recording_saved`. Full contract in `docs/ZMNEXT_TASKS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)