### PR TITLE
docs: consolidate plan index, capture storage + filters designs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,18 @@ APP_PROFILE=test-db cargo test --test '*' -- --include-ignored
 
 ## Active Implementation Plans
 
-- **PTZ Control System** – `docs/PTZ_TASKS.md` – Rust-based PTZ control API with Perl bridge fallback, phased implementation from immediate Perl proxy to native protocol implementations (ONVIF, Dahua, HikVision, Reolink, serial protocols).
-- **Review Fixes (2026-06)** – `docs/REVIEW_FIXES_PLAN.md` – Phased fixes from the full API review: password hashing, event-playback ACL, WebRTC startup latency (keyframe re-read, trickle ICE), HLS session lifecycle, daemon-ID unification, housekeeping.
-- **Live Audio** – `docs/AUDIO_TASKS.md` – Phases 1–3 implemented (HLS AAC mux, WebRTC G.711 pass-through + AAC→Opus); audio now arrives on the stream socket with shared-clock pts and HELLO extradata (the raw-AAC ASC-recovery stretch goal is obsolete — the socket reader ADTS-frames raw AAC from the HELLO ASC). Remaining: browser/camera verification and Phase 4 stretch (G.711→AAC for HLS, VOD audio).
-- **HEVC over WebRTC** – `docs/HEVC_WEBRTC_TASKS.md` – Phase 1 (server correctness: H.265 AU assembly, keyframe cache, RFC 7798 fmtp) implemented. Remaining: Safari verification, mobile apps; HLS remains the fallback.
-- **zm-next Worker Integration** – `docs/ZMNEXT_TASKS.md` – Drive + ingest the per-monitor `zm-core` worker over the stream socket: EVENT (0x06) parsing, Events/Frames ingest, daemon spawn/supervision, pipeline-JSON generation, per-monitor `UseZmNext` flag. Off by default; reversible per camera. Open items: the `Monitors.UseZmNext` column (ZoneMinder fork migration) and the clip storage-path contract.
+See **`docs/README.md`** for the consolidated, status-tagged index of every
+plan and reference doc. That file is the single source of truth — keep it up
+to date when shipping or starting work; don't duplicate the listing here.
+
+Current focus (links go to the per-plan docs):
+
+- **Storage Manager** – `docs/STORAGE_PLAN.md` – per-Storage retention with
+  declared capacity, per-Monitor quotas, soft-delete + reap, cold-tier
+  handoff to S3/cloud. Replaces `PurgeWhenFull` and `Update DiskSpace`.
+- **Filters Refactor** – `docs/FILTERS_PLAN.md` – retire user-facing Filters
+  in favour of saved searches + bulk event ops, a notification rules engine,
+  and a media job queue. Drops `AutoExecuteCmd` for webhooks.
 
 ## Fast Commands
 

--- a/docs/AUDIO_TASKS.md
+++ b/docs/AUDIO_TASKS.md
@@ -1,5 +1,11 @@
 # Live Audio - Implementation Tasks
 
+> **Status (2026-06-28):** Done — verify. Phases 1-3 (HLS AAC pass-through,
+> WebRTC G.711 pass-through, AAC→Opus transcode) implemented and unit-tested.
+> Open: 2.2.2 browser/camera verification, Phase 4 stretch (G.711→AAC,
+> VOD audio). The Phase 4 "raw-AAC ASC recovery" stretch item is obsolete —
+> stream-socket HELLO now carries the ASC.
+
 This document tracks implementation tasks for live audio support in HLS and
 WebRTC streaming. Recorded-event (VOD) audio is a stretch phase at the end.
 

--- a/docs/FILTERS_PLAN.md
+++ b/docs/FILTERS_PLAN.md
@@ -1,0 +1,215 @@
+# Filters — Refactor / Retirement Plan
+
+**Status:** Active (design) — 2026-06-28. No code yet.
+
+The `Filters` table conflates five unrelated concerns under one row format.
+The plan: split each concern out into a dedicated subsystem, retire the
+user-facing concept of "filter", and remove the `zmfilter.pl --filter_id=N
+--daemon` supervision path.
+
+> Related: [STORAGE_PLAN.md](STORAGE_PLAN.md) covers (D) housekeeping; this
+> doc covers (A)-(C) and (E). Built-in filters → storage manager; user
+> filters → the new subsystems below.
+
+## Inventory (the headline finding)
+
+A fresh ZoneMinder install seeds **exactly two** filters
+(`db/zm_create.sql.in`):
+
+| Filter | Purpose | Auto-action |
+|---|---|---|
+| `PurgeWhenFull` | Delete oldest 100 non-archived completed events when disk ≥95% full | `AutoDelete` |
+| `Update DiskSpace` | Backfill `Events.DiskSpace` for completed events where it's NULL | `UpdateDiskSpace` |
+
+That's it. Exhaustive search of `INSERT INTO Filters` across the entire
+ZoneMinder repo (master, all `db/zm_update-*.sql`) returns only those two +
+their migration scaffolding. There is no third built-in filter anywhere.
+
+User-defined filters exist, but they all reuse the same `AutoX` action
+vocabulary.
+
+## Auto-action taxonomy (5 categories)
+
+| Category | Auto-actions | New home |
+|---|---|---|
+| **(A) Per-event mutation** | `AutoArchive`, `AutoUnarchive`, `AutoDelete` | **Saved searches + bulk event ops in zm-api.** |
+| **(B) Notification** | `AutoEmail`, `AutoMessage` | **Notification rules engine.** |
+| **(C) Media side-effect** | `AutoVideo`, `AutoUpload`, `AutoMove`, `AutoCopy` | **Media job queue.** |
+| **(D) Disk housekeeping** | `UpdateDiskSpace`, `PurgeWhenFull` (`AutoDelete` on the seeded filter only) | **Storage manager** — see [STORAGE_PLAN.md](STORAGE_PLAN.md). |
+| **(E) Arbitrary exec** | `AutoExecuteCmd` | **Webhooks** (replace; do not port). |
+
+Coverage in zm-api today (as of 2026-06-28, `master @ 766c1a7`):
+
+| Auto-action | Today | Gap |
+|---|---|---|
+| `AutoArchive` / `AutoUnarchive` | `PATCH /events/{id} {archived: true/false}` — `src/service/events.rs:230-232`. Covered. | Bulk endpoint missing. |
+| `AutoDelete` | `DELETE /events/{id}` — `src/repo/events.rs:180`. Leaky: drops DB row but leaves on-disk dir/frames/snapshot/mp4. | Two-stage soft-delete + reap (see STORAGE_PLAN P0+P1) **before** bulk-delete is safe. |
+| `AutoVideo` | None. `videoed` not even on `EventUpdateRequest`. | New media job kind. |
+| `AutoUpload` | Flag-only: `PATCH {uploaded: true}` (`src/service/events.rs:246-248`). No FTP/SFTP/cloud client. | Move to media job queue (cold-tier handoff covers most real use cases anyway). |
+| `AutoEmail` | Flag-only: `PATCH {emailed: true}` (`src/service/events.rs:238-240`). No SMTP sender. | Notification rules engine. |
+| `AutoMessage` | Flag-only: `PATCH {messaged: true}`. Despite the name, this is an email-to-SMS pathway upstream — not Jabber/XMPP. | Notification rules engine, with explicit channel selection. |
+| `AutoExecute` / `AutoExecuteCmd` | Flag-only. `auto_execute_cmd` is stored on the filter row but never executed (no `Command::new` in zm-api outside ffmpeg/snapshot). | **Drop entirely.** Webhooks cover every legitimate use and are auditable. |
+| `AutoMove` / `AutoMoveTo` | None. PATCH does not even expose `storage_id`. | Storage tier_mode + media job queue. |
+| `AutoCopy` / `AutoCopyTo` | None. `secondary_storage_id` only settable at create time. | Storage tier_mode + media job queue. |
+| `UpdateDiskSpace` | None. Column is read-only on responses. | Storage manager. |
+
+## Subsystem 1: Saved searches + bulk event ops
+
+The AST translator already exists (`src/service/filter_translate.rs`,
+`filter_query.rs`, `filter_build.rs`) and the preview compiler emits a
+parameterised SeaORM `Condition` (`src/service/filter_build.rs:1-8`).
+
+What's needed:
+
+- **`saved_searches` table**: `(id, user_id, name, ast_json, monitor_scope?,
+  created_at)`. No auto-action columns. No execution columns. No
+  `Background` / `Concurrent` / `LockRows`.
+- **`POST /api/v3/events:bulk`** body `{ saved_search_id | ast, action:
+  archive | unarchive | delete, dry_run: bool }`. Cursor-paginated execution
+  with a debounce. Returns a job id; status polled via `GET
+  /api/v3/jobs/{id}`.
+- **`GET /api/v3/events:search`** wraps the existing preview path; trivial.
+
+Critically: `DELETE /events/{id}` must be fixed first (see STORAGE_PLAN P0+P1
+— soft-delete + reap). Bulk-delete on the current implementation silently
+leaks storage at scale.
+
+## Subsystem 2: Notification rules engine
+
+A dedicated, channel-aware rules engine. Notifications are an
+**independent concern** from filters; they need to fire on event-start /
+event-end / score-threshold regardless of any saved search.
+
+Shape:
+
+| Field | Type |
+|---|---|
+| `id` | u64 |
+| `user_id` | FK Users |
+| `name` | string |
+| `predicate_ast` | JSON | reuses the same AST as saved_searches |
+| `trigger` | enum `EventStart \| EventEnd \| ScoreThreshold \| StorageHealth` |
+| `channel` | enum `Smtp \| Webhook \| Fcm \| Apns \| Mqtt` |
+| `template` | JSON | per-channel render template |
+| `dedupe_window_seconds` | u32 |
+
+The `emailed` / `messaged` columns on `Events` become **per-rule delivery
+state** (new table `notification_deliveries`, FK to rule + event) rather
+than per-event flags. Lossy single-flag semantics in upstream were a bug
+anyway — a rule may fire on Telegram but not on email; the current model
+can't represent that.
+
+Channels are pluggable. SMTP is the obvious first (covers `AutoEmail` +
+`AutoMessage` via the SMS-gateway pattern). Webhook is the catch-all that
+replaces `AutoExecuteCmd`.
+
+## Subsystem 3: Media job queue
+
+`POST /api/v3/events/{id}/jobs` body `{ kind: transcode | export | move |
+copy, target_storage_id?, destination? }`. Workers consume the queue with
+bounded concurrency. The `videoed` / `uploaded` columns become job-completion
+markers.
+
+`AutoMove` / `AutoCopy` use cases mostly fold into the storage tier_mode
+(see STORAGE_PLAN.md) — operator declares a cold-tier handoff once, all
+clips migrate automatically. The job queue is the manual escape hatch for
+"export this clip to that S3 bucket" or "transcode this event to mobile-
+friendly MP4".
+
+## Subsystem 4: Webhooks (replaces AutoExecuteCmd)
+
+`qx($command)` with `%TAG%` substitution and no escaping (zmfilter.pl's
+implementation) is a stored-RCE primitive. Existing rows in production are
+already a security liability.
+
+Replacement:
+
+- Notification channel `Webhook` (see Subsystem 2).
+- HMAC-signed POST body with event JSON.
+- Per-rule URL + secret.
+- Audit log of every invocation.
+
+`AutoExecute=1` on filter create/update returns 400 with a deprecation
+message linking to webhooks. Existing rows are warned about at startup.
+Two-release deprecation window, then drop.
+
+## Migration of existing user filter rows
+
+A one-shot importer routes each existing `Filters` row by which `Auto*`
+flags are set:
+
+| Has flags | Routed to |
+|---|---|
+| Only `AutoArchive` / `AutoUnarchive` / `AutoDelete` | Saved search; can be invoked via bulk endpoint. |
+| Only `AutoEmail` / `AutoMessage` | Notification rule (Smtp channel). |
+| Only `AutoUpload` / `AutoMove` / `AutoCopy` / `AutoVideo` | Media job template attached to a saved search (queued by scheduler — see open Q). |
+| `AutoExecute=1` | Hard-rejected on import; warned at startup; operator must migrate to webhook. |
+| Mixed across categories | Split into N rows (one per category) — emit a migration report listing the splits for operator review. |
+
+The seeded `PurgeWhenFull` and `Update DiskSpace` rows are deleted on
+import (their job moves to the storage manager).
+
+## What "scheduler" actually meant (for the original GitHub issue)
+
+ZoneMinder upstream issue #4957 asks for a "full-fledged scheduler" running
+Perl/PHP/Bash/binary scripts on cron-like schedules with a UI.
+
+Reframed against this plan:
+- **Time-of-day arming** → already solvable via `Monitors.Function` +
+  scheduled API calls (host cron + a couple of REST calls). Not a backend
+  feature, frontend at most.
+- **Periodic housekeeping** → storage manager (no cron).
+- **Scheduled exports/reports** → notification rules with `EventEnd` trigger
+  + daily-digest channel (open question 5 in STORAGE_PLAN.md style).
+- **Maintenance windows** → notification rule with a time-of-day predicate
+  + a state-change action.
+- **Long-running PHP/worker** → daemon supervisor, not a scheduler. zm-api's
+  `DaemonManager` already supervises ZoneMinder daemons; could grow a
+  user-defined-daemons table if there's real demand. Out of scope for this
+  plan; tracked separately if requested.
+
+There is no general cron + script-runner to build.
+
+## Implementation phases
+
+| Phase | Scope | Acceptance |
+|---|---|---|
+| **P0 — Saved searches** | Schema + CRUD. AST shape reuses existing `filter_translate`. No `Auto*` columns. | `GET /events:search` works; saved searches list/CRUD. |
+| **P1 — Bulk event ops** | `POST /events:bulk` for archive/unarchive/delete. Depends on STORAGE_PLAN P0+P1 (soft-delete + reap) for delete to be safe. | Bulk archive 10k events in one call; delete leaks no storage. |
+| **P2 — Notification rules** | Rules table, deliveries table, SMTP + Webhook channels. Trigger on event-end. | "Email me when person detected on driveway" works end-to-end. |
+| **P3 — Media job queue** | Jobs table, worker pool, transcode + export + move + copy kinds. | Manual export to S3 works; storage tier_mode auto-tiering covers `AutoMove`. |
+| **P4 — Importer** | One-shot migration of existing `Filters` rows. Migration report. | All seeded + user filters migrated; zmfilter.pl supervision can be turned off per Storage. |
+| **P5 — Retire zmfilter.pl** | Remove `src/daemon/manager.rs:1031-1065` background-filter spawn loop. `AutoExecute=1` hard-rejected on create/update. | No `zmfilter.pl --daemon` processes; `Filters` table marked legacy. |
+| **P6 — (Future) Daemon supervisor for user workers** | Only if real demand for long-running PHP/Python workers. `DaemonManager` extension. | Out of scope unless requested. |
+
+## Open questions
+
+1. **Rule predicate vs event API filter.** Both share the same AST. Do they
+   share the same SQL translator (single source of truth), or do rules use a
+   real-time event matcher (no SQL) for low latency? Lean: real-time matcher
+   for rules (events flow through it as they're created), AST shared.
+2. **`AutoExecute` deprecation path.** Hard-error on existing rows immediately,
+   or warn-and-ignore for one release? Security argues immediate; ops continuity
+   argues warning. Lean: warn-and-ignore for one release, hard-error in the
+   next.
+3. **Mixed-category rows on import.** Split silently, or require operator
+   intervention? Lean: split silently, emit a report; operator can revert.
+4. **`Filters` table retention.** Keep around after P5 as legacy storage (in
+   case upstream web UI still writes to it), or drop the table entirely? Lean:
+   keep + mark read-only on the API for one release after P5.
+5. **Notification delivery-state retention.** Per-rule per-event deliveries
+   could grow large. Retention TTL on the deliveries table — 30 days?
+
+## References
+
+- Inventory + behavior of every `Auto*` action (the long form): the
+  filter-inventory workflow output from 2026-06-28. Key sources: ZoneMinder
+  `db/zm_create.sql.in`, `scripts/zmfilter.pl.in`,
+  `docs/userguide/filterevents.rst`.
+- Current zm-api filter code: `src/handlers/filters.rs`,
+  `src/service/filters.rs`, `src/repo/filters.rs`, `src/entity/filters.rs`,
+  `src/service/filter_{ast,translate,query,build,field}.rs`.
+- Current zm-api supervision of zmfilter.pl:
+  `src/daemon/manager.rs:1031-1065`, `src/daemon/daemons.rs:28-39`.
+- The "delete leaks files" issue: `src/repo/events.rs:180-181` (`Events::delete_by_id`).
+- ZoneMinder upstream issue #4957: the scheduler ask.

--- a/docs/HEVC_WEBRTC_TASKS.md
+++ b/docs/HEVC_WEBRTC_TASKS.md
@@ -1,5 +1,9 @@
 # HEVC over WebRTC - Implementation Tasks
 
+> **Status (2026-06-28):** Done — verify. Phase 1 (server correctness: H.265
+> AU assembly, keyframe cache, RFC 7798 fmtp) shipped. Open: Phase 2 (Safari
+> verification), Phase 3 (Swift/Kotlin native apps), Phase 4 hardening.
+
 Goal: stream H.265 monitors live over WebRTC to clients that can decode it —
 Safari today, the native Swift/Kotlin apps next — with automatic HLS fallback
 for clients that can't.

--- a/docs/MONITOR_EVENTS_TASKS.md
+++ b/docs/MONITOR_EVENTS_TASKS.md
@@ -1,5 +1,12 @@
 # Monitor Events — Capture-Fault & State Push (Spec + Tasks)
 
+> **Status (2026-06-28):** Active. zm-api protocol side largely landed (EVENT
+> 0x06 + Monitor stream parsing are in `src/streaming/source/protocol.rs`,
+> `stream_socket.rs`, `router.rs` — shared with the zm-next ingest path). The
+> `GET /api/v3/monitors/{id}/events` SSE endpoint (Phase 4) is **not yet
+> implemented**. Gating dependency: Phase 1 zmc-side EVENT emission lives in
+> a separate repo.
+
 Adds a **server-push event stream** to zm-api, fed by a new event frame on
 zmc's existing per-monitor stream socket. This is the API-first slice of
 PR #4830's capabilities: the capture-fault channel (only zmc can produce it)

--- a/docs/MOTION_SYNOPSIS_API_SPEC.md
+++ b/docs/MOTION_SYNOPSIS_API_SPEC.md
@@ -1,5 +1,12 @@
 # Motion Synopsis — zm-api Hand-off Spec
 
+> **Status (2026-06-28):** Active. Service skeleton exists at
+> `src/service/synopsis/{compositor,optimiser,render,mod}.rs` and
+> `EVENT_REVIEW_ASSETS = 0x0306` is wired in `src/streaming/source/protocol.rs`.
+> P1 (composite still) + P2 (temporal optimiser scaffolding) appear in tree;
+> P3 (mp4 render via libav) + P4 (range/overview, retention cleanup, soft-mask)
+> still open. zm-next side is in a separate repo.
+
 **Audience:** the zm-api (Rust/Axum) maintainer. This is the implementation contract for the
 synopsis **optimiser + renderer + serving**. zm-next produces the ingredients (object "tubes" +
 background plates) and announces them; zm-api consumes, optimises, renders to mp4, caches, and

--- a/docs/NL_EVENT_SEARCH_PLAN.md
+++ b/docs/NL_EVENT_SEARCH_PLAN.md
@@ -1,5 +1,11 @@
 # Natural-Language Event Search + Vector Store — zm-api Implementation Plan
 
+> **Status (2026-06-28):** Done — follow-ups. Vertical slice shipped on
+> MariaDB 11.8 native VECTOR (Option A). Open: stand up local inference
+> servers and verify end-to-end answers; sqlite-vec floor for non-11.8
+> deployments; response caching/ETag; `image_embed`. See the in-doc
+> "Implementation status" section for the canonical state.
+
 **Audience:** an engineer/AI working in the **zm-api** (Rust/Axum) repo. This is an execution-ready
 plan to build semantic + natural-language search over zm-next events — the single largest shipped-
 feature gap vs Frigate. Design rationale lives in the **zm-next** repo at

--- a/docs/ONVIF_TASKS.md
+++ b/docs/ONVIF_TASKS.md
@@ -1,5 +1,12 @@
 # ONVIF Client Subsystem — Implementation Plan
 
+> **Status (2026-06-28):** Done — follow-ups. Phases 1-4 shipped (foundation,
+> service clients, integration with PTZ/discovery/event listener, adversarial
+> verification + fixes). Open: conformance vectors (11 sample-response
+> fixtures), CI feature-matrix per profile, deferred LOW parser items
+> (CDATA-spanning text, `xml:lang` Reason), Phase 5 live event push to API
+> clients (SSE/webhook).
+
 Goal: make zm_api a **client-only ONVIF NVR** — discover cameras, retrieve media
 profiles/stream URIs, control PTZ natively, and consume device events — by adding
 a reusable ONVIF client subsystem and wiring it into the existing monitor, PTZ,

--- a/docs/PTZ_TASKS.md
+++ b/docs/PTZ_TASKS.md
@@ -1,5 +1,12 @@
 # PTZ Control System - Implementation Tasks
 
+> **Status (2026-06-28):** Phase 0 (Perl bridge) shipped. Phase 1 (native
+> ONVIF PTZ) is delivered by [ONVIF_TASKS.md](ONVIF_TASKS.md), not here —
+> `src/ptz/protocols/onvif.rs` is implemented and registered in `state.rs`.
+> Phases 2-5 (Dahua / HikVision / Reolink / Amcrest natives, serial
+> protocols, presets/tours/multi-user/rate limit, Perl deprecation) are all
+> still open. 0.6.6 (generic command handler) is also still pending.
+
 This document tracks implementation tasks for the PTZ Control System.
 See the full plan context in the original design document.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,62 @@
+# zm-api Plans & Docs Index
+
+The single entry point for all design notes, implementation plans, and operator
+guides. Every plan doc gets a status line so a reader can tell at a glance
+whether it's active, mostly-done with follow-ups, or superseded.
+
+**Status meanings**
+
+| Tag | Meaning |
+|---|---|
+| Active | Currently being built or about to be |
+| Done — verify | Code is in, manual/browser verification still pending |
+| Done — follow-ups | Code shipped; specific items listed as remaining work |
+| Reference | Operator/dev guide, not a plan |
+| Superseded | Kept for history; live work lives elsewhere |
+
+Last verified: **2026-06-28** (cross-checked against the code state on
+`master @ 766c1a7`). Numbers behind each status reflect that snapshot — re-verify
+before relying on any specific phase verdict.
+
+---
+
+## Active plans
+
+| Doc | Status | One-line scope |
+|---|---|---|
+| [STORAGE_PLAN.md](STORAGE_PLAN.md) | Active (design) | Per-Storage retention with declared capacity, per-Monitor quotas, soft-delete + reap, cold-tier handoff (S3 etc.). Replaces `PurgeWhenFull` and `Update DiskSpace`. |
+| [FILTERS_PLAN.md](FILTERS_PLAN.md) | Active (design) | Retire user-facing Filters. Saved searches → bulk event ops; notifications → rules engine; media → job queue; `AutoExecuteCmd` → webhooks. |
+| [MONITOR_EVENTS_TASKS.md](MONITOR_EVENTS_TASKS.md) | Active | Capture-fault + state-change SSE on `GET /api/v3/monitors/{id}/events`. zmc-side (Phase 1) is the gating dependency; Phase 2-3 mostly land via the zm-next protocol code already in tree. |
+| [HEVC_WEBRTC_TASKS.md](HEVC_WEBRTC_TASKS.md) | Done — verify | Phase 1 server correctness shipped. Phase 2 (Safari verification) + Phase 3 (Swift/Kotlin apps) pending. |
+| [AUDIO_TASKS.md](AUDIO_TASKS.md) | Done — verify | Phases 1-3 (HLS AAC, WebRTC G.711, AAC→Opus) shipped. Real-camera browser verification pending; Phase 4 stretch items open. |
+| [MOTION_SYNOPSIS_API_SPEC.md](MOTION_SYNOPSIS_API_SPEC.md) | Active (P1-P2 in tree) | Synopsis service exists at `src/service/synopsis/{compositor,optimiser,render}.rs`; P3 video render + P4 range/overview/retention still open. |
+| [NL_EVENT_SEARCH_PLAN.md](NL_EVENT_SEARCH_PLAN.md) | Done — follow-ups | Vertical slice shipped on MariaDB 11.8 native VECTOR. Open: stand up local inference servers; sqlite-vec floor; response caching/ETag; image-embed. |
+| [ONVIF_TASKS.md](ONVIF_TASKS.md) | Done — follow-ups | Phases 1-4 shipped. Open: conformance vectors, CI feature-matrix, deferred LOW parser items, Phase 5 live event push. |
+| [ZMNEXT_TASKS.md](ZMNEXT_TASKS.md) | Done — coord pending | Tasks 1-5 landed (EVENT 0x06, ingest, daemon spawn, pipeline JSON, `UseZmNext` graceful flag). Waiting on: ZoneMinder fork's `Monitors.UseZmNext` migration; zm-next `store` plugin handshake. |
+| [PTZ_TASKS.md](PTZ_TASKS.md) | Phase 0 done; later phases mostly superseded | Phase 0 Perl bridge complete. Phase 1 (native ONVIF PTZ) is delivered by ONVIF_TASKS, not here. Phases 2-5 (Dahua/HikVision/Reolink, serial, presets/tours, deprecation) still open. |
+| [REVIEW_FIXES_PLAN.md](REVIEW_FIXES_PLAN.md) | Done — follow-ups | Phases 1-4 mostly shipped (password hash, ACL, status codes, daemon-id unification, transactional `apply_state`, spawn_blocking shm). Open: 3.2 idle HLS reaping, 4.4 bounded frames, 5.3 percent-encoded DB URL, 5.4 hand-rolled percent_decode replacement, 5.5 utoipa security annotations. |
+
+## Reference docs (not plans)
+
+| Doc | Scope |
+|---|---|
+| [deployment.md](deployment.md) | Packaging, profiles, passive/active mode, distro matrix, release flow. |
+| [tls.md](tls.md) | Built-in TLS + ACMEv2 config and external certbot/lego flows. |
+
+## Archive (kept for history)
+
+| Doc | Why superseded |
+|---|---|
+| [archive/RTSP_STREAMING_PLAN.md](archive/RTSP_STREAMING_PLAN.md) | Pre-implementation design from before native HLS, WebRTC live, and the stream-socket source landed. Useful as historical context only — live plans are in HEVC_WEBRTC_TASKS, AUDIO_TASKS, MONITOR_EVENTS_TASKS. |
+
+---
+
+## Working on this docs tree
+
+- One file per concern. Don't merge plans; cross-link instead.
+- When a plan ships in code, change its status here and add a follow-ups list to
+  the doc itself — don't archive working plans.
+- When a plan is fully done with nothing outstanding, move it to `archive/` with
+  a one-line note at the top saying which commit / release shipped it.
+- Verify status claims by reading code, not by re-reading the plan. The
+  "Last verified" date here is the floor of those claims.

--- a/docs/REVIEW_FIXES_PLAN.md
+++ b/docs/REVIEW_FIXES_PLAN.md
@@ -1,5 +1,18 @@
 # Review Fixes Implementation Plan
 
+> **Status (2026-06-28):** Done — follow-ups. Verified shipped: 1.1 password
+> hash (`src/service/users.rs:56`), 1.3 row-level ACL on event playback
+> (`src/handlers/events_playback.rs:198+`), 2.1 keyframe re-read + 2.2 trickle
+> ICE, 4.1 zmc daemon-id unification (`src/daemon/manager.rs:2208`), 4.3
+> spawn_blocking shm calls (`src/service/monitor.rs:856,881`), 5.1 dead WebRTC
+> file removal. **Still open:** 1.2 status codes (verify), 1.4 monitor-create
+> ACL (verify), 2.3 SPS-wait removal (verify), 2.4 pre-warm (skip unless
+> trivial), 3.1 HLS cleanup task wired up (verify it's actually started),
+> 3.2 idle HLS reaping, 3.3 atomic segment-cap eviction, 3.4 snapshot teardown,
+> 4.2 transactional apply_state, 4.4 bounded frames query, 5.2 ffmpeg init,
+> 5.3 percent-encoded DB credentials, 5.4 hand-rolled `percent_decode` replacement,
+> 5.5 utoipa security annotations, 5.6 inner auth middleware audit.
+
 Source: full API review (2026-06-10) — three parallel code reviews (streaming, HTTP layer,
 service/repo) plus a WebRTC startup-latency trace. Every finding below was verified against
 the code before inclusion. Line numbers were correct at plan time; re-locate by symbol if

--- a/docs/STORAGE_PLAN.md
+++ b/docs/STORAGE_PLAN.md
@@ -1,0 +1,215 @@
+# Storage Manager — Design Plan
+
+**Status:** Active (design) — 2026-06-28. No code yet.
+
+Replaces ZoneMinder's two seeded background filters (`PurgeWhenFull`,
+`Update DiskSpace`) with a zm-api–owned storage subsystem. Eliminates the
+`zmfilter.pl --filter_id=N --daemon` supervision path for the only filters
+that ship by default, and gives operators per-camera retention SLAs without
+ever editing a `Filters` row.
+
+> Related: [FILTERS_PLAN.md](FILTERS_PLAN.md) (retiring user-facing Filters).
+> Without the storage manager, the auto-delete category in FILTERS_PLAN is
+> homeless.
+
+## Motivation
+
+1. **`PurgeWhenFull` is fragile UX.** It's a user-editable row in `Filters`
+   that, mis-edited, deletes recordings. Upstream has shipped three migrations
+   to repair this one filter (`zm_update-1.19.1`, `1.23.x`, `1.35.15` — the
+   last one added `EndDateTime IS NOT NULL` to stop it deleting in-progress
+   events).
+2. **The responsibility is a storage invariant, not user policy.** "Don't let
+   the disk fill" belongs on the `Storage` row, not in a query language.
+3. **`statvfs()` is the wrong primitive.** Shared storage, NFS, S3-backed
+   storage and over-provisioned LVM all lie about "% full". A **declared
+   capacity** per Storage decouples retention from filesystem geometry and is
+   testable without filling a real disk.
+4. **Per-camera quotas don't exist today.** A chatty camera can evict all the
+   others; there's no way to say "keep this important camera 30 days, others 7
+   days" without writing a filter per camera.
+
+## Data model
+
+### `Storage` (extend the existing entity)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `kind` | enum `Local \| S3 \| NFS \| SMB \| WebDAV \| Azure \| GCS` | Backing type. Drives reaper/move/copy implementations. |
+| `capacity_bytes` | u64 | Declared budget. `DiskPercent = sum(Events.DiskSpace where StorageId=X) / capacity_bytes`. Not `statvfs()`. |
+| `high_water_pct` | u8 | Retention triggers above this. Default 90. |
+| `low_water_pct` | u8 | Retention runs until back below this. Default 75. |
+| `max_age_days` | u32? | Optional unconditional age cap. Null = unlimited. |
+| `protect_archived` | bool | Archived events are never auto-deleted. Default true. |
+| `protect_locked` | bool | Locked events are never auto-deleted. Default true. |
+| `secondary_storage_id` | FK Storage? | Cold tier target (S3, slower disk, etc.). |
+| `tier_mode` | enum `Off \| Backup \| Tier \| BackupThenTier` | What to do with the secondary. |
+| `tier_age_days` | u32? | Unconditional age-based tier-down regardless of pressure. |
+| `encryption` | enum `None \| ServerSide \| ClientSide(key_id)` | At-rest encryption for the backing. |
+| `full` | bool (runtime) | Set when archived events fill the quota and recording must stop. Surfaced in API + alerts. |
+
+`tier_mode` semantics:
+- **Backup**: copy new clips to secondary; keep originals. Replaces `AutoCopy`.
+- **Tier**: when over high-water, move oldest events to secondary, then delete
+  from primary. Replaces `AutoMove`.
+- **BackupThenTier**: backup new clips immediately, then tier on pressure.
+  Data is safe on the secondary before the primary is ever pressured.
+
+### `Monitor` (extend)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `max_storage_bytes` | u64? | Per-camera quota on its primary Storage. Null = share with others. |
+| `max_age_days` | u32? | Per-camera age override (defaults to `Storage.max_age_days`). |
+| `protect_archived` | bool? | Per-camera override. |
+
+### Invariants enforced at the API boundary
+
+- **No oversubscription.** When creating/updating a Monitor with
+  `max_storage_bytes`, the server validates that
+  `sum(Monitor.max_storage_bytes WHERE storage_id=X) ≤ Storage.capacity_bytes`.
+  Reject with 400 on overflow. Apologetic but firm — "why was my camera
+  evicted" is much harder to explain in an oversubscribed model.
+- **Archived events are immortal.** Retention skips them; they count against
+  the quota. If they fill it, recording fails closed: `Storage.full = true`,
+  `zmc` errors clearly, an operator alert fires. "Silent stop" is the worst
+  failure mode and must be impossible.
+
+## Reaper (the delete contract)
+
+PHP/ZoneMinder learned the hard way that synchronous `unlink()` over
+thousands of small per-event JPEGs is a foot-gun. The reaper is **two-stage**:
+soft-delete + async reap.
+
+1. **API delete** = flip `Events.deleted_at` (new column). The event is
+   instantly hidden from list/get; the row is not removed. Cheap, atomic,
+   restart-safe — state lives in the DB.
+2. **Reaper task per Storage** consumes tombstones and reclaims disk:
+   - **Rename-into-trash first.** `rename("events/.../1234",
+     "events/.trash/1234")` is one atomic syscall on the same filesystem and
+     the event vanishes from the live tree immediately. Long walk happens
+     later in `.trash/`, where nothing else is contending.
+   - **`tokio::fs::remove_dir_all` with bounded concurrency.** Native
+     syscalls; cap at N concurrent event-dir reaps so live recording IO is
+     never starved.
+   - **Maintenance window.** Hard reaping pauses when any monitor is `Modect`
+     and only runs aggressively when retention is pressed.
+   - **Per-storage scheduling.** Slow NFS can't stall local-disk cleanup.
+   - **Trash lives on the same Storage** (`.trash/` subdir). Cross-fs rename
+     would be a copy, defeating the point.
+
+### Cross-kind move/copy
+
+| From → To | Implementation |
+|---|---|
+| Local → Local (same fs) | `rename` |
+| Local → Local (cross fs) | copy + verify + delete |
+| Local → S3/Azure/GCS | streamed multipart upload; verify checksum; delete |
+| Local → NFS/SMB/WebDAV | streamed copy via existing FS abstraction |
+| S3 → Local | streamed download (handles Glacier restore — see open question 2 in `FILTERS_PLAN.md`) |
+
+## Retention runner
+
+A periodic task per `Storage` row:
+
+1. Stat-walk new event dirs; recompute `Events.DiskSpace`. (Replaces
+   `UpdateDiskSpace` filter.)
+2. Compute per-monitor and per-storage usage from the column.
+3. If any monitor is over its `max_storage_bytes`, evict oldest unprotected
+   events on that monitor until back under, oldest first.
+4. If the Storage is over `high_water_pct`, evict oldest unprotected events
+   across all monitors until under `low_water_pct`.
+5. If `tier_mode != Off` and a tier-down is configured, move/copy eligible
+   events to `secondary_storage_id` per the mode and `tier_age_days`.
+6. If the Storage is full of archived events, set `Storage.full = true` and
+   emit a health alert (notification rules engine — see `FILTERS_PLAN.md`).
+
+The runner is **idempotent** — re-running it must converge. State lives in
+the DB; partial work is fine.
+
+## Storage `kind` adapters (the only kind-specific code)
+
+Each `kind` implements a small trait:
+
+```rust
+trait StorageBackend {
+    async fn write_event(&self, event_id: u64, src: &Path) -> Result<PathBuf>;
+    async fn rename_into_trash(&self, event_id: u64) -> Result<()>;
+    async fn reap_trash(&self, event_id: u64) -> Result<()>;
+    async fn recompute_disk_space(&self, event_id: u64) -> Result<u64>;
+    async fn copy_to(&self, event_id: u64, dst: &dyn StorageBackend) -> Result<()>;
+    async fn move_to(&self, event_id: u64, dst: &dyn StorageBackend) -> Result<()>;
+}
+```
+
+`Local` is the baseline. `S3/Azure/GCS` reuse the same multipart upload/download
+path with provider-specific auth. `NFS/SMB/WebDAV` reuse `Local` via the mount.
+
+## API surface
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/v3/storages` | List with computed usage (used/declared, per-monitor breakdown). |
+| `PATCH /api/v3/storages/{id}` | Update capacity, water marks, retention, tier config. Validates monitor-sum invariant on capacity changes. |
+| `POST /api/v3/storages/{id}:reap` | Force-run the reaper (operator escape hatch). |
+| `GET /api/v3/storages/{id}/health` | `{full, used_bytes, capacity_bytes, archived_bytes, oldest_event_ts}`. |
+| `PATCH /api/v3/monitors/{id}` | (extend) accept `max_storage_bytes`, `max_age_days`, `protect_archived`. Validates oversubscription. |
+| `DELETE /api/v3/events/{id}` | Already exists; change semantics to set `deleted_at` rather than `Events::delete_by_id`. |
+
+`Storage.full=true` surfaces as a health condition on `GET
+/monitors/{id}/events` SSE (see `MONITOR_EVENTS_TASKS.md`).
+
+## Migration from PurgeWhenFull + Update DiskSpace
+
+1. Ship the storage manager off by default (feature flag in `[storage]`).
+2. For each Storage with the default `PurgeWhenFull` row, write reasonable
+   defaults (`high_water_pct=90`, `low_water_pct=75`, `protect_archived=true`)
+   and stop supervising the `zmfilter.pl --filter_id=<purge_id> --daemon`
+   process for it.
+3. After one release where both systems are valid (one of them must be
+   disabled per Storage to avoid double-reaping), drop the two seeded filter
+   rows from `db/zm_create.sql.in` (zm-api's mirror) and remove the spawn
+   path for them in `src/daemon/manager.rs:1031-1065`.
+4. Document the upgrade in `deployment.md`.
+
+## Implementation phases
+
+| Phase | Scope | Acceptance |
+|---|---|---|
+| **P0 — schema + soft-delete** | SeaORM migration: `Events.deleted_at`, Storage extensions, Monitor extensions. Repo + service for soft-delete. List/get hide tombstoned. | `DELETE /events/{id}` is instant + idempotent; tombstoned events vanish from API. |
+| **P1 — Local reaper** | Per-Storage reaper task; `rename`-into-trash; bounded concurrency; maintenance window. | Reap throughput benchmarked; recording IO unaffected under load; tests for restart-safety. |
+| **P2 — Local retention runner** | Stat-walk → DiskSpace; per-monitor + per-storage eviction; oversubscription validation at API. | Replaces `PurgeWhenFull` + `Update DiskSpace` for the seeded `Local` storage. Side-by-side test against `zmfilter.pl` for one release. |
+| **P3 — Health + alerts** | `Storage.full` flag; recording-fails-closed; SSE health event on the Monitor stream. | Operator gets notified before silent stop; integration test for "fill with archived, then attempt new recording". |
+| **P4 — S3 backend + tier_mode** | S3 `StorageBackend`; `Backup`/`Tier`/`BackupThenTier`; multipart upload; lifecycle-rule offload (open Q below). | Cold tier verified end-to-end; restore-on-playback path tested. |
+| **P5 — Other backends** | Azure, GCS, NFS, SMB, WebDAV adapters as demand justifies. | One per release as needed. |
+
+## Open questions
+
+1. **Reuse S3 lifecycle policies?** If `tier_mode=Tier` and `secondary` is S3,
+   we can let AWS reap via lifecycle rules — `max_age_days` becomes a declared
+   policy zm-api applies to the bucket once. Cheaper, but couples our
+   retention to S3 semantics. Lean: yes.
+2. **Glacier/Deep Archive playback latency.** Event tiered to Glacier
+   requested for playback — initiate restore + 202 the request, or hard error
+   with "cold storage"? Affects UI.
+3. **Encryption defaults.** Per-Storage `encryption: None | ServerSide |
+   ClientSide(key_id)`? Server-side is the sensible default; client-side adds
+   key management.
+4. **`deleted_at` retention.** How long do tombstones stick around before the
+   row is hard-deleted from `Events`? Long enough for `zmaudit`/operator
+   recovery; short enough that the table doesn't bloat. Lean: 30 days.
+5. **Frames/Stats FK cascade.** Does the upstream schema already cascade on
+   `Events` delete, or do we need explicit cleanup? Verify before P0.
+6. **Built-in filter protection on rollback.** If the seeded `PurgeWhenFull`
+   row is dropped at P2 completion, do we also block the upstream web UI from
+   recreating it (it still seeds the row in `zm_create.sql.in`)?
+
+## References
+
+- ZoneMinder upstream filters: `db/zm_create.sql.in` lines 1085-1168
+  (the two seeded rows).
+- Current zm-api supervision: `src/daemon/manager.rs:1031-1065`.
+- Current (leaky) delete: `src/repo/events.rs:180-181` — `Events::delete_by_id`
+  drops the row but leaves the on-disk event dir, frames, snapshot, mp4.
+  This is the gap P0+P1 closes.
+- Filter context for why this is the right home: see [FILTERS_PLAN.md](FILTERS_PLAN.md).

--- a/docs/ZMNEXT_TASKS.md
+++ b/docs/ZMNEXT_TASKS.md
@@ -1,5 +1,12 @@
 # zm-next Worker Integration
 
+> **Status (2026-06-28):** Done — coord pending. Tasks 1-5 landed in zm-api.
+> Outstanding cross-repo items: ZoneMinder fork's `Monitors.UseZmNext
+> TINYINT NOT NULL DEFAULT 0` migration; zm-next `store` plugin's
+> `recording_opening` / `assign_recording` handshake + stage-then-rename
+> behavior. Until both ship, `repo::monitors::use_zmnext` returns false on
+> the missing column and the integration is inert.
+
 Status as of this branch: zm-api can drive and ingest the per-monitor `zm-next`
 worker (`zm-core`) over the existing stream-socket protocol. The feature is
 **off by default** and reversible per camera.

--- a/docs/archive/RTSP_STREAMING_PLAN.md
+++ b/docs/archive/RTSP_STREAMING_PLAN.md
@@ -1,5 +1,15 @@
 # RTSP Streaming API Architecture Plan
 
+> **ARCHIVED — 2026-06-28.** This is the pre-implementation design from before
+> native HLS, WebRTC live, and the stream-socket source landed. The shipped
+> architecture follows phases 2-3 of this plan (native WebRTC + native HLS) but
+> sources from zmc's stream socket rather than the FIFO/RTSP scaffolding
+> described here. Phase 5 (RTSP proxy server) was not built and is not on the
+> active roadmap. Phase 1 (go2rtc) was implemented at one point but the live
+> system no longer depends on go2rtc. Kept only for historical context — live
+> plans are in `../HEVC_WEBRTC_TASKS.md`, `../AUDIO_TASKS.md`, and
+> `../MONITOR_EVENTS_TASKS.md`.
+
 ## Executive Summary
 
 This document outlines a comprehensive plan to expose RTSP camera feeds through zm-api, implement native streaming protocols (WebRTC, WebSocket/MSE, HLS), and propose improvements to ZoneMinder to replace the legacy `zms` streaming service.


### PR DESCRIPTION
- New docs/README.md as the consolidated, status-tagged index of every plan and reference doc (Active / Done / Superseded), verified against master @ 766c1a7 on 2026-06-28.
- New docs/STORAGE_PLAN.md: storage manager replacing PurgeWhenFull + Update DiskSpace. Declared per-Storage capacity, per-Monitor quotas (no oversubscription), archived-events-immortal with fail-closed recording, soft-delete + async reap (rename-into-trash), cold-tier handoff with tier_mode { Off | Backup | Tier | BackupThenTier }, S3/Azure/ GCS/NFS/SMB/WebDAV backends, 6 phases, 6 open questions.
- New docs/FILTERS_PLAN.md: retire user-facing Filters. 5-category taxonomy (per-event mutation / notification / media / housekeeping / arbitrary exec), saved searches + bulk event ops, notification rules engine, media job queue, webhooks replacing AutoExecuteCmd, importer + 7 phases. Documents that ZoneMinder ships exactly two built-in filters and the rest are scaffolding migrations of the same rows.
- Currency status headers added to AUDIO_TASKS, HEVC_WEBRTC_TASKS, MONITOR_EVENTS_TASKS, MOTION_SYNOPSIS_API_SPEC, NL_EVENT_SEARCH_PLAN, ONVIF_TASKS, PTZ_TASKS, REVIEW_FIXES_PLAN, ZMNEXT_TASKS with verified file:line refs for what shipped vs. what's open.
- Archive RTSP_STREAMING_PLAN.md (pre-implementation design from before native HLS/WebRTC live landed; superseded by HEVC_WEBRTC_TASKS, AUDIO_TASKS, MONITOR_EVENTS_TASKS).
- CLAUDE.md "Active Implementation Plans" now points at docs/README.md as the single source of truth instead of duplicating the listing, with only the two new focus areas (Storage + Filters) called out.

