### PR TITLE
fix(deps): resolve 2026 security-audit failures (quick-xml 0.41, dep bumps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -781,9 +781,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64",
  "blowfish",
@@ -3470,9 +3470,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4281,21 +4281,21 @@ dependencies = [
 
 [[package]]
 name = "phonenumber"
-version = "0.3.9+9.0.21"
+version = "0.3.10+9.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
+checksum = "66d85d3cc5477bfe2f357939e7f02a5a566632508633af1a2c37577d0bef87d9"
 dependencies = [
  "either",
  "fnv",
  "nom",
  "once_cell",
  "postcard",
- "quick-xml 0.38.4",
+ "quick-xml",
  "regex",
  "regex-cache",
  "serde",
  "serde_derive",
- "strum 0.27.2",
+ "strum 0.26.3",
  "thiserror 2.0.18",
 ]
 
@@ -4548,28 +4548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4654,18 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5505,12 +5474,11 @@ dependencies = [
 
 [[package]]
 name = "sea-bae"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6088,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -6357,14 +6325,8 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -6378,13 +6340,14 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.117",
 ]
 
@@ -8379,7 +8342,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "pkg-config",
- "quick-xml 0.37.5",
+ "quick-xml",
  "rand 0.9.4",
  "rand_core 0.9.5",
  "rcgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 sentry = "0.48"
 # ONVIF SOAP client: XML envelope build/parse and WS-Security SHA-1 digest.
-quick-xml = "0.37"
+quick-xml = "0.41"
 sha1 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,10 @@ ignore = [
     # atomic-polyfill unmaintained. Deep transitive build-dep only
     # (garde -> phonenumber -> postcard -> heapless), no safe upgrade available.
     "RUSTSEC-2023-0089",
+    # paste unmaintained. Proc-macro pulled in only by tikv-jemalloc-ctl (a
+    # dev-dependency used by the jemalloc stats test); no tikv-jemalloc-ctl
+    # release without it. Compile-time only, never in the shipped binary.
+    "RUSTSEC-2024-0436",
 ]
 
 [bans]

--- a/src/onvif/device.rs
+++ b/src/onvif/device.rs
@@ -259,16 +259,37 @@ fn local_name(qname: &[u8]) -> String {
     }
 }
 
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Read the text content of the element currently open in `reader` (the parser
-/// is positioned just after a `Start` event). Returns the accumulated, escaped
-/// text, stopping at the matching `End`. Tolerant of empty elements.
+/// is positioned just after a `Start` event). Returns the accumulated,
+/// entity-resolved text, stopping at the matching `End`. Tolerant of empty
+/// elements. Callers trim the result.
 fn read_text(reader: &mut Reader<&[u8]>) -> String {
     let mut depth = 0usize;
     let mut out = String::new();
     loop {
         match reader.read_event() {
             Ok(Event::Text(t)) if depth == 0 => {
-                out.push_str(&t.unescape().unwrap_or_default());
+                out.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) if depth == 0 => {
+                out.push_str(&resolve_ref(&r));
             }
             Ok(Event::CData(t)) if depth == 0 => {
                 out.push_str(&String::from_utf8_lossy(t.as_ref()));
@@ -293,7 +314,6 @@ fn read_text(reader: &mut Reader<&[u8]>) -> String {
 /// leaves any absent field as `None`.
 fn parse_device_information(xml: &str) -> OnvifResult<DeviceInformation> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut info = DeviceInformation::default();
     loop {
@@ -326,7 +346,6 @@ fn parse_device_information(xml: &str) -> OnvifResult<DeviceInformation> {
 /// encountered within it. Matching is by local name, so any prefix works.
 fn parse_capabilities(xml: &str) -> OnvifResult<Capabilities> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut caps = Capabilities::default();
     // Stack of local element names, used to know which service category an
@@ -383,7 +402,6 @@ fn assign_xaddr(caps: &mut Capabilities, category: &str, addr: Option<String>) {
 /// `<Service>` element; missing children stay `None`.
 fn parse_services(xml: &str) -> OnvifResult<Vec<Service>> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut services = Vec::new();
     let mut current: Option<Service> = None;
@@ -491,6 +509,23 @@ mod tests {
         );
         assert_eq!(info.serial_number.as_deref(), Some("SN-ABC-12345"));
         assert_eq!(info.hardware_id.as_deref(), Some("HW-7788"));
+    }
+
+    #[test]
+    fn device_info_with_entity_references() {
+        // quick-xml ≥ 0.38 splits `Bosch &amp; Co` into text / GeneralRef /
+        // text events; read_text must reassemble it, spaces included.
+        let xml = r#"<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+          <s:Body>
+            <tds:GetDeviceInformationResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+              <tds:Manufacturer>Bosch &amp; Co</tds:Manufacturer>
+              <tds:Model>IPC&#45;2000</tds:Model>
+            </tds:GetDeviceInformationResponse>
+          </s:Body>
+        </s:Envelope>"#;
+        let info = parse_device_information(xml).expect("parse");
+        assert_eq!(info.manufacturer.as_deref(), Some("Bosch & Co"));
+        assert_eq!(info.model.as_deref(), Some("IPC-2000"));
     }
 
     #[test]

--- a/src/onvif/discovery.rs
+++ b/src/onvif/discovery.rs
@@ -229,7 +229,6 @@ impl DiscoveryClient {
 /// automatically).
 pub fn parse_probe_matches(xml: &str) -> Vec<ProbeMatch> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut matches: Vec<ProbeMatch> = Vec::new();
     // The match currently being assembled (between ProbeMatch start/end).
@@ -238,6 +237,9 @@ pub fn parse_probe_matches(xml: &str) -> Vec<ProbeMatch> {
     // belongs to the endpoint reference only when nested under
     // `EndpointReference`).
     let mut stack: Vec<String> = Vec::new();
+    // Text of the innermost open element, accumulated across the text and
+    // entity-reference events it may be split into; consumed at its End.
+    let mut buf = String::new();
 
     loop {
         match reader.read_event() {
@@ -247,14 +249,22 @@ pub fn parse_probe_matches(xml: &str) -> Vec<ProbeMatch> {
                     current = Some(ProbeMatch::default());
                 }
                 stack.push(local);
+                buf.clear();
             }
             Ok(Event::Text(t)) => {
-                if let Some(m) = current.as_mut() {
-                    let text = t.unescape().unwrap_or_default().into_owned();
-                    apply_text(m, &stack, &text);
-                }
+                buf.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) => {
+                buf.push_str(&resolve_ref(&r));
             }
             Ok(Event::End(e)) => {
+                if let Some(m) = current.as_mut() {
+                    let text = buf.trim();
+                    if !text.is_empty() {
+                        apply_text(m, &stack, text);
+                    }
+                }
+                buf.clear();
                 let local = local_name(e.name().as_ref());
                 if local == "ProbeMatch" {
                     if let Some(m) = current.take() {
@@ -363,6 +373,23 @@ fn hex_val(b: u8) -> Option<u8> {
         b'a'..=b'f' => Some(b - b'a' + 10),
         b'A'..=b'F' => Some(b - b'A' + 10),
         _ => None,
+    }
+}
+
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
     }
 }
 
@@ -495,6 +522,25 @@ mod tests {
         assert_eq!(m.name.as_deref(), Some("ACME Cam 1"));
         assert_eq!(m.hardware.as_deref(), Some("IPC-Model-X"));
         assert_eq!(m.location.as_deref(), Some("country/us"));
+    }
+
+    #[test]
+    fn xaddrs_with_escaped_query_stays_one_url() {
+        // An XAddr whose query string carries `&amp;` is split into several
+        // text/GeneralRef events by quick-xml ≥ 0.38; it must be reassembled
+        // into a single URL, not two.
+        let xml = r#"<e:Envelope xmlns:e="http://www.w3.org/2003/05/soap-envelope"
+            xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery">
+          <e:Body><d:ProbeMatches><d:ProbeMatch>
+            <d:XAddrs>http://10.0.0.7/onvif/device_service?a=1&amp;b=2</d:XAddrs>
+          </d:ProbeMatch></d:ProbeMatches></e:Body>
+        </e:Envelope>"#;
+        let matches = parse_probe_matches(xml);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].xaddrs,
+            vec!["http://10.0.0.7/onvif/device_service?a=1&b=2".to_string()]
+        );
     }
 
     #[test]

--- a/src/onvif/events.rs
+++ b/src/onvif/events.rs
@@ -337,7 +337,6 @@ impl EventsClient {
 /// a `SubscriptionReference` subtree.
 fn parse_create_pull_point(xml: &str) -> OnvifResult<PullPointSubscription> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut sub = PullPointSubscription::default();
     let mut stack: Vec<String> = Vec::new();
@@ -399,7 +398,6 @@ fn parse_create_pull_point(xml: &str) -> OnvifResult<PullPointSubscription> {
 /// ```
 fn parse_pull_messages(xml: &str) -> OnvifResult<PullMessagesResponse> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut out = PullMessagesResponse::default();
     // The element subtree we are currently inside, by local name. Used to
@@ -505,7 +503,6 @@ fn parse_pull_messages(xml: &str) -> OnvifResult<PullMessagesResponse> {
 /// Parse a `RenewResponse`, returning the device's new `TerminationTime` if any.
 fn parse_renew(xml: &str) -> Option<String> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     loop {
         match reader.read_event() {
@@ -541,23 +538,46 @@ fn local_name(qname: &[u8]) -> String {
 fn attr_value(e: &quick_xml::events::BytesStart<'_>, local: &str) -> Option<String> {
     for attr in e.attributes().with_checks(false).flatten() {
         if local_name(attr.key.as_ref()) == local {
-            let raw = attr.unescape_value().unwrap_or_default();
+            let raw = attr
+                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
+                .unwrap_or_default();
             return Some(raw.into_owned());
         }
     }
     None
 }
 
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Read the text content of the element currently open in `reader` (positioned
 /// just after a `Start` event). Accumulates text/CDATA at the top level,
 /// stopping at the matching `End`. Tolerant of nested elements and empties.
+/// Callers trim the result.
 fn read_text(reader: &mut Reader<&[u8]>) -> String {
     let mut depth = 0usize;
     let mut out = String::new();
     loop {
         match reader.read_event() {
             Ok(Event::Text(t)) if depth == 0 => {
-                out.push_str(&t.unescape().unwrap_or_default());
+                out.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) if depth == 0 => {
+                out.push_str(&resolve_ref(&r));
             }
             Ok(Event::CData(t)) if depth == 0 => {
                 out.push_str(&String::from_utf8_lossy(t.as_ref()));

--- a/src/onvif/media.rs
+++ b/src/onvif/media.rs
@@ -245,6 +245,23 @@ fn local_name(qname: &[u8]) -> String {
     }
 }
 
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Find an attribute by local name (prefix-agnostic) on a start tag.
 fn attr_local<'a>(e: &'a quick_xml::events::BytesStart<'a>, want: &str) -> Option<String> {
     for attr in e.attributes().flatten() {
@@ -263,13 +280,15 @@ fn attr_local<'a>(e: &'a quick_xml::events::BytesStart<'a>, want: &str) -> Optio
 /// captured when present.
 fn parse_profiles(xml: &str) -> OnvifResult<Vec<MediaProfile>> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut profiles: Vec<MediaProfile> = Vec::new();
     // Local-name stack used to scope where text belongs.
     let mut stack: Vec<String> = Vec::new();
     // The profile currently being assembled (between Profiles start/end).
     let mut current: Option<MediaProfile> = None;
+    // Text of the innermost open element, accumulated across the text and
+    // entity-reference events it may be split into; consumed at its End.
+    let mut buf = String::new();
 
     loop {
         match reader.read_event() {
@@ -284,6 +303,7 @@ fn parse_profiles(xml: &str) -> OnvifResult<Vec<MediaProfile>> {
                     current = Some(p);
                 }
                 stack.push(local);
+                buf.clear();
             }
             Ok(Event::Empty(e)) => {
                 // Self-closing element: may carry the token attribute (rare, but
@@ -300,16 +320,21 @@ fn parse_profiles(xml: &str) -> OnvifResult<Vec<MediaProfile>> {
                 }
             }
             Ok(Event::Text(t)) => {
-                if let Some(p) = current.as_mut() {
-                    let text = t.unescape().unwrap_or_default().into_owned();
-                    if text.is_empty() {
-                        // Skip whitespace-only nodes.
-                    } else if let Some(local) = stack.last() {
-                        assign_profile_field(p, &stack, local, &text);
-                    }
-                }
+                buf.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) => {
+                buf.push_str(&resolve_ref(&r));
             }
             Ok(Event::End(e)) => {
+                if let Some(p) = current.as_mut() {
+                    let text = buf.trim();
+                    if !text.is_empty() {
+                        if let Some(local) = stack.last() {
+                            assign_profile_field(p, &stack, local, text);
+                        }
+                    }
+                }
+                buf.clear();
                 let local = local_name(e.name().as_ref());
                 if local == "Profiles" || local == "Profile" {
                     if let Some(p) = current.take() {
@@ -384,41 +409,49 @@ fn ancestor_is(stack: &[String], name: &str) -> bool {
 /// same shape: a `<Uri>` plus optional validity metadata.
 fn parse_media_uri(xml: &str) -> OnvifResult<MediaUri> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut out = MediaUri::default();
     let mut found_uri = false;
     let mut stack: Vec<String> = Vec::new();
+    // Text of the innermost open element, accumulated across the text and
+    // entity-reference events it may be split into; consumed at its End.
+    let mut buf = String::new();
 
     loop {
         match reader.read_event() {
             Ok(Event::Start(e)) => {
                 stack.push(local_name(e.name().as_ref()));
+                buf.clear();
             }
             Ok(Event::Text(t)) => {
-                let text = t.unescape().unwrap_or_default().into_owned();
-                if text.is_empty() {
-                    // ignore whitespace
-                } else if let Some(local) = stack.last() {
-                    match local.as_str() {
-                        "Uri" if !found_uri => {
-                            out.uri = text;
-                            found_uri = true;
-                        }
-                        "InvalidAfterConnect" => {
-                            out.invalid_after_connect = parse_bool(&text);
-                        }
-                        "InvalidAfterReboot" => {
-                            out.invalid_after_reboot = parse_bool(&text);
-                        }
-                        "Timeout" => {
-                            out.timeout = Some(text);
-                        }
-                        _ => {}
-                    }
-                }
+                buf.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) => {
+                buf.push_str(&resolve_ref(&r));
             }
             Ok(Event::End(_)) => {
+                let text = buf.trim();
+                if !text.is_empty() {
+                    if let Some(local) = stack.last() {
+                        match local.as_str() {
+                            "Uri" if !found_uri => {
+                                out.uri = text.to_string();
+                                found_uri = true;
+                            }
+                            "InvalidAfterConnect" => {
+                                out.invalid_after_connect = parse_bool(text);
+                            }
+                            "InvalidAfterReboot" => {
+                                out.invalid_after_reboot = parse_bool(text);
+                            }
+                            "Timeout" => {
+                                out.timeout = Some(text.to_string());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                buf.clear();
                 stack.pop();
             }
             Ok(Event::Eof) => break,
@@ -682,6 +715,46 @@ mod tests {
         assert_eq!(uri.invalid_after_connect, None);
         assert_eq!(uri.invalid_after_reboot, None);
         assert_eq!(uri.timeout, None);
+    }
+
+    /// A stream URI whose query string carries an escaped `&amp;` and a numeric
+    /// character reference. quick-xml ≥ 0.38 reports these as separate
+    /// `GeneralRef` events, so the parser must reassemble the full URI.
+    const STREAM_URI_ESCAPED_QUERY: &str = r#"<?xml version="1.0"?>
+    <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+      <s:Body>
+        <trt:GetStreamUriResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl"
+                                  xmlns:tt="http://www.onvif.org/ver10/schema">
+          <trt:MediaUri>
+            <tt:Uri>rtsp://cam.local:554/stream?user=admin&amp;channel=1&amp;pw=a&#37;b</tt:Uri>
+          </trt:MediaUri>
+        </trt:GetStreamUriResponse>
+      </s:Body>
+    </s:Envelope>"#;
+
+    #[test]
+    fn parses_stream_uri_with_escaped_query_params() {
+        let uri = parse_media_uri(STREAM_URI_ESCAPED_QUERY).expect("parse");
+        assert_eq!(
+            uri.uri,
+            "rtsp://cam.local:554/stream?user=admin&channel=1&pw=a%b"
+        );
+    }
+
+    #[test]
+    fn profile_name_with_entity_keeps_surrounding_spaces() {
+        let xml = r#"<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+          <s:Body>
+            <trt:GetProfilesResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl"
+                                     xmlns:tt="http://www.onvif.org/ver10/schema">
+              <trt:Profiles token="P1">
+                <tt:Name>Day &amp; Night</tt:Name>
+              </trt:Profiles>
+            </trt:GetProfilesResponse>
+          </s:Body>
+        </s:Envelope>"#;
+        let profiles = parse_profiles(xml).expect("parse");
+        assert_eq!(profiles[0].name.as_deref(), Some("Day & Night"));
     }
 
     #[test]

--- a/src/onvif/ptz.rs
+++ b/src/onvif/ptz.rs
@@ -364,17 +364,37 @@ fn local_name(qname: &[u8]) -> String {
     }
 }
 
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
+    }
+}
+
 /// Read the text content of the element currently open in `reader` (the parser
-/// is positioned just after a `Start` event). Returns the accumulated, escaped
-/// text, stopping at the matching `End`. Tolerant of nested elements / empty
-/// elements.
+/// is positioned just after a `Start` event). Returns the accumulated,
+/// entity-resolved text, stopping at the matching `End`. Tolerant of nested
+/// elements / empty elements. Callers trim the result.
 fn read_text(reader: &mut Reader<&[u8]>) -> String {
     let mut depth = 0usize;
     let mut out = String::new();
     loop {
         match reader.read_event() {
             Ok(Event::Text(t)) if depth == 0 => {
-                out.push_str(&t.unescape().unwrap_or_default());
+                out.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) if depth == 0 => {
+                out.push_str(&resolve_ref(&r));
             }
             Ok(Event::CData(t)) if depth == 0 => {
                 out.push_str(&String::from_utf8_lossy(t.as_ref()));
@@ -408,7 +428,9 @@ fn non_empty(s: String) -> Option<String> {
 fn attr_f32(e: &quick_xml::events::BytesStart, want: &str) -> Option<f32> {
     for attr in e.attributes().flatten() {
         if local_name(attr.key.as_ref()) == want {
-            let raw = attr.unescape_value().ok()?;
+            let raw = attr
+                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
+                .ok()?;
             return raw.trim().parse::<f32>().ok();
         }
     }
@@ -420,7 +442,7 @@ fn attr_str(e: &quick_xml::events::BytesStart, want: &str) -> Option<String> {
     for attr in e.attributes().flatten() {
         if local_name(attr.key.as_ref()) == want {
             return attr
-                .unescape_value()
+                .normalized_value(quick_xml::XmlVersion::Implicit1_0)
                 .ok()
                 .map(|c| c.trim().to_string())
                 .filter(|s| !s.is_empty());
@@ -435,7 +457,6 @@ fn attr_str(e: &quick_xml::events::BytesStart, want: &str) -> Option<String> {
 /// shape used inside a single `<...Position>` block of a GetStatus response.
 fn parse_vector(xml: &str) -> PtzVector {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut vec = PtzVector::default();
     loop {
@@ -476,7 +497,6 @@ fn parse_status(xml: &str) -> OnvifResult<PtzStatus> {
     let position = parse_vector(xml);
 
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut status = PtzStatus {
         position,
@@ -532,7 +552,6 @@ fn parent_is(stack: &[String], local: &str) -> bool {
 /// `PTZConfiguration`; missing children stay `None`.
 fn parse_configurations(xml: &str) -> OnvifResult<Vec<PtzConfiguration>> {
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut configs = Vec::new();
     let mut current: Option<PtzConfiguration> = None;

--- a/src/onvif/transport.rs
+++ b/src/onvif/transport.rs
@@ -179,7 +179,6 @@ fn parse_soap_fault(xml: &str) -> Option<(String, String)> {
     use quick_xml::reader::Reader;
 
     let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
 
     let mut in_fault = false;
     let mut in_code_value = false;
@@ -194,6 +193,9 @@ fn parse_soap_fault(xml: &str) -> Option<(String, String)> {
     let mut reason: Option<String> = None;
     // Local-name stack to interpret Value/Text context.
     let mut stack: Vec<String> = Vec::new();
+    // Text of the Value/Text element currently open, accumulated across the
+    // text and entity-reference events it may be split into.
+    let mut buf = String::new();
 
     loop {
         match reader.read_event() {
@@ -203,36 +205,50 @@ fn parse_soap_fault(xml: &str) -> Option<(String, String)> {
                     "Fault" => in_fault = true,
                     "Value" if in_fault && parent_is(&stack, "Code") => {
                         in_code_value = true;
+                        buf.clear();
                     }
                     "Value" if in_fault && parent_is(&stack, "Subcode") => {
                         in_subcode_value = true;
+                        buf.clear();
                     }
                     "Text" if in_fault && parent_is(&stack, "Reason") => {
                         in_reason_text = true;
+                        buf.clear();
                     }
                     _ => {}
                 }
                 stack.push(local);
             }
-            Ok(Event::Text(t)) => {
-                if in_code_value && code.is_none() {
-                    // Top-level code: first (outermost) Value wins.
-                    code = Some(t.unescape().unwrap_or_default().into_owned());
-                } else if in_subcode_value {
-                    // Subcode: last (innermost / most specific) Value wins.
-                    subcode = Some(t.unescape().unwrap_or_default().into_owned());
-                } else if in_reason_text && reason.is_none() {
-                    reason = Some(t.unescape().unwrap_or_default().into_owned());
-                }
+            Ok(Event::Text(t)) if in_code_value || in_subcode_value || in_reason_text => {
+                buf.push_str(&t.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(r)) if in_code_value || in_subcode_value || in_reason_text => {
+                buf.push_str(&resolve_ref(&r));
             }
             Ok(Event::End(e)) => {
                 let local = local_name(e.name().as_ref());
                 match local.as_str() {
                     "Value" => {
+                        let text = buf.trim();
+                        if in_code_value && code.is_none() && !text.is_empty() {
+                            // Top-level code: first (outermost) Value wins.
+                            code = Some(text.to_string());
+                        } else if in_subcode_value && !text.is_empty() {
+                            // Subcode: last (innermost / most specific) Value wins.
+                            subcode = Some(text.to_string());
+                        }
+                        buf.clear();
                         in_code_value = false;
                         in_subcode_value = false;
                     }
-                    "Text" => in_reason_text = false,
+                    "Text" => {
+                        let text = buf.trim();
+                        if in_reason_text && reason.is_none() && !text.is_empty() {
+                            reason = Some(text.to_string());
+                        }
+                        buf.clear();
+                        in_reason_text = false;
+                    }
                     "Fault" => in_fault = false,
                     _ => {}
                 }
@@ -268,6 +284,23 @@ fn local_name(qname: &[u8]) -> String {
     match s.rsplit_once(':') {
         Some((_, local)) => local.to_string(),
         None => s.into_owned(),
+    }
+}
+
+/// Resolve a general entity / character reference event (`&amp;`, `&#37;`, …)
+/// to its replacement text. quick-xml ≥ 0.38 reports references as separate
+/// `Event::GeneralRef`s instead of unescaping them inside text events.
+/// Unknown entities resolve to the empty string, matching the old lossy
+/// `unescape().unwrap_or_default()` behaviour.
+fn resolve_ref(r: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = r.resolve_char_ref() {
+        return ch.to_string();
+    }
+    match r.decode() {
+        Ok(name) => quick_xml::escape::resolve_predefined_entity(&name)
+            .unwrap_or_default()
+            .to_string(),
+        Err(_) => String::new(),
     }
 }
 
@@ -332,6 +365,21 @@ mod tests {
         let (code, reason) = parse_soap_fault(xml).expect("fault parsed");
         assert_eq!(code, "Receiver");
         assert_eq!(reason, "Internal Error");
+    }
+
+    #[test]
+    fn fault_reason_with_entity_reference_is_reassembled() {
+        // quick-xml ≥ 0.38 splits `Locked &amp; unauthorized` into text /
+        // GeneralRef / text events; the parser must reassemble the full
+        // reason including the spaces around the entity.
+        let xml = r#"<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+          <s:Body><s:Fault>
+            <s:Code><s:Value>s:Sender</s:Value></s:Code>
+            <s:Reason><s:Text xml:lang="en">Locked &amp; unauthorized</s:Text></s:Reason>
+          </s:Fault></s:Body></s:Envelope>"#;
+        let (code, reason) = parse_soap_fault(xml).expect("fault parsed");
+        assert_eq!(code, "s:Sender");
+        assert_eq!(reason, "Locked & unauthorized");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The **Security audit** CI job (`cargo audit` + `cargo deny`) was failing on master with 5 vulnerabilities and yanked-crate warnings from the 2026 advisory wave. This PR fixes everything fixable and documents the one remaining unfixable warning.

### Dependency fixes
- **quick-xml 0.37 → 0.41** — fixes RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (both high-severity DoS)
- **phonenumber 0.3.9 → 0.3.10** — collapses the second (vulnerable) quick-xml 0.38.4 copy so the whole tree shares one fixed 0.41
- `cargo update`: **bcrypt 0.19.2** (RUSTSEC-2026-0199), **anyhow 1.0.104** (RUSTSEC-2026-0190), **memmap2 0.9.11** (RUSTSEC-2026-0186), **spin 0.9.9** (0.9.8 was yanked), **sea-bae 0.2.2** (drops unmaintained proc-macro-error2, RUSTSEC-2026-0173 — no ignore needed)

### ONVIF parser rework (required by quick-xml ≥ 0.38)
Since 0.38, quick-xml no longer unescapes entities inside text events: `BytesText::unescape()` is gone and references arrive as separate `Event::GeneralRef` events. A URI like `rtsp://cam/stream?user=a&amp;pass=b` now spans three events, and the old parsers assigned on the first text event — silently truncating entity-containing values. The parsers in `src/onvif/` now accumulate text across split events and resolve references via module-local `resolve_ref` helpers (following the existing helper-per-module convention). Attribute reads moved to `normalized_value()`. Spaces adjacent to entities are preserved (`Day &amp; Night` → `Day & Night`).

### deny.toml
Added a documented ignore for **paste** (RUSTSEC-2024-0436) — an unmaintained proc-macro reached only via the `tikv-jemalloc-ctl` dev-dependency; compile-time only, never in the shipped binary. It is warning-class in cargo-audit, so the workflow `--ignore` mirror is unchanged (same convention as RUSTSEC-2023-0089).

## Test plan
- [x] New regression tests: stream URIs with escaped query params, profile names with entities, SOAP fault reasons, device info, multi-URL `XAddrs` discovery
- [x] `cargo test --all-features` — 766 passed (1 pre-existing failure is `test_get_cargo_project_root`, which asserts the checkout dir name and only fails in git worktrees; passes in CI)
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo audit --ignore RUSTSEC-2023-0071` and `cargo deny check` both pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)