### PR TITLE
Dashboard fixes batch 2: storage response fields (#24)

### DIFF
--- a/src/dto/response/storage.rs
+++ b/src/dto/response/storage.rs
@@ -8,6 +8,12 @@ pub struct StorageResponse {
     pub name: String,
     pub path: String,
     pub r#type: String,
+    pub scheme: String,
+    pub server_id: Option<u32>,
+    pub url: Option<String>,
+    /// Configured capacity in bytes (`Storages.DiskSpace`), if set.
+    pub disk_space: Option<i64>,
+    pub do_delete: i8,
     pub enabled: i8,
 }
 
@@ -18,6 +24,14 @@ impl From<&crate::entity::storage::Model> for StorageResponse {
             name: m.name.clone(),
             path: m.path.clone(),
             r#type: m.r#type.to_string(),
+            scheme: serde_json::to_value(&m.scheme)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_default(),
+            server_id: m.server_id,
+            url: m.url.clone(),
+            disk_space: m.disk_space,
+            do_delete: m.do_delete,
             enabled: m.enabled,
         }
     }


### PR DESCRIPTION
Follow-up batch after #14, continuing the dashboard-readiness issue backlog.

- **#24** — expose `scheme`, `server_id`, `url`, `disk_space`, `do_delete` on `StorageResponse` (clients could write these but not read them back). Per-storage disk-usage / event count+size is noted as a follow-up.

More backlog items (#23 users, #26 per-frame image, #27 API tokens, #30 bulk export, #31 filters execute, #32 spec hygiene, #34 media tokens, #35 no-auth mode, #36 event-audit rollup, #37 legacy controls, plus the request-side field additions for #22/#24/#25) will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)