### PR TITLE
Fix shipped-default defects and add the docs a release needs (#50, #51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Cheap gate: catch a half-finished version bump before spending three
+  # package builds on it. The four version strings are hand-synced.
+  versions:
+    name: Version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-version-consistency.sh
+
   # Debian/Ubuntu/Raspberry Pi OS — the flagship, built natively per arch.
   deb:
     name: deb (${{ matrix.arch }})
@@ -44,7 +53,11 @@ jobs:
         run: cargo install cargo-deb --locked
 
       - name: Build .deb
-        run: cargo deb
+        # Build every bin target first: the asset list ships `migrator` as
+        # zm_api-db alongside the server, and cargo-deb only copies paths.
+        run: |
+          cargo build --release --bins
+          cargo deb --no-build
 
       - name: Sanity-check package (no private keys, lists files)
         run: |
@@ -154,9 +167,46 @@ jobs:
 
   # Attach every artifact that built to the GitHub Release. Runs on tags only;
   # `always()` so a single distro failure still publishes the rest.
+  # The OpenAPI spec as a release asset: lets the API surface be diffed between
+  # releases and fed to a client generator without standing a server up.
+  openapi:
+    name: OpenAPI spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install FFmpeg/OpenSSL dev libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libssl-dev \
+            libavutil-dev libavformat-dev libavfilter-dev \
+            libavdevice-dev libavcodec-dev libswscale-dev libswresample-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Export spec
+        run: cargo run --release --bin zm_api -- --openapi > openapi.json
+
+      - name: Sanity-check spec
+        run: |
+          python3 -c "
+          import json, sys
+          spec = json.load(open('openapi.json'))
+          paths = len(spec.get('paths', {}))
+          print(f'openapi {spec[\"openapi\"]}, {paths} paths')
+          sys.exit(0 if paths > 50 else 'suspiciously few paths')
+          "
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi
+          path: openapi.json
+
   release:
     name: Publish release
-    needs: [deb, rpm, arch]
+    needs: [deb, rpm, arch, openapi]
     if: always() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -168,11 +218,42 @@ jobs:
       - name: List artifacts
         run: ls -lR artifacts || true
 
+      # So a downloader can verify what they got. Paths are flattened to bare
+      # filenames, which is how they appear on the release page.
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          find . -type f ! -name 'SHA256SUMS' -printf '%P\n' \
+            | sort \
+            | xargs -r sha256sum > SHA256SUMS
+          cat SHA256SUMS
+
+      # The hand-written entry for this version, if CHANGELOG.md has one. Falls
+      # back to GitHub's generated commit list, which is better than nothing but
+      # says little to someone deciding whether to upgrade.
+      - uses: actions/checkout@v4
+        with: { path: src }
+
+      - name: Extract release notes
+        id: notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if awk -v v="$version" '
+                /^## \[/ { inside = index($0, "[" v "]") > 0; next }
+                inside   { print }
+              ' src/CHANGELOG.md > notes.md && [ -s notes.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no CHANGELOG.md entry for ${version}; using generated notes"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/**
           fail_on_unmatched_files: false
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.found == 'true' && 'notes.md' || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.found != 'true' }}
           # Any SemVer pre-release tag (contains a hyphen, e.g. v3.0.0-alpha.1)
           # is published as a GitHub pre-release.
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to zm_api are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning is
+[SemVer](https://semver.org/) — carrying the `v3` major from ZoneMinder's API
+lineage, so a client written against the legacy `/api/v3` surface has a
+recognisable path forward.
+
+## [Unreleased]
+
+### Added
+- Man pages: `zm_api(8)`, `zm_api.env(5)`, `zm_api-takeover(8)`, `zm_api-db(8)`.
+- `zm_api --help`, `--version`, and `--openapi` (writes the OpenAPI spec to
+  stdout, so the API surface can be diffed or fed to a client generator without
+  running a server). All three work before configuration is loaded, so they
+  still answer on a host whose config is broken.
+- The migration tool ships as `/usr/bin/zm_api-db` in all three packages. It was
+  previously built but packaged nowhere, leaving no upgrade path for an existing
+  ZoneMinder database.
+- `server.allowed_origins` (`APP_SERVER__ALLOWED_ORIGINS`) as a documented,
+  `APP_`-prefixed setting, accepting a TOML array or a comma-separated string.
+- `docs/architecture.md`: how ZoneMinder, zm_api, and a dashboard fit together —
+  what must share a host, serving the frontend, ports, and the auth surface.
+- The OpenAPI spec is exported in CI and attached to each release, alongside a
+  `SHA256SUMS` file covering every artifact.
+- Release notes are taken from this file's entry for the tag, falling back to
+  GitHub's generated commit list only when there isn't one.
+- `scripts/check-version-consistency.sh`, run in CI before any package is built,
+  so a half-finished version bump fails fast.
+
+### Fixed
+- **A configured TURN server had no effect.** `AppState` built the WebRTC engine
+  from defaults rather than the loaded `[streaming.webrtc]` config, so
+  `stun_servers` and `turn` were parsed, validated, and discarded — viewers
+  behind symmetric NAT could not connect, with nothing in the log to explain it.
+- **CORS was undiscoverable.** The allowed-origin list came from a bare,
+  un-prefixed `ALLOWED_ORIGINS` variable that appeared in no config file and no
+  documentation, defaulting to localhost. A dashboard on any other origin was
+  silently blocked with no string in the repo to grep for. The variable is still
+  honoured (with a deprecation warning) so existing deployments keep working; the
+  effective list and its source are now logged at startup.
+- **`APP_DAEMON__SCRIPT_PATH` shipped a value wrong for Debian and Ubuntu.** One
+  env file serves all three package formats, and no single value suits every
+  distribution, so daemon paths are now resolved by searching the standard
+  locations, with the setting as an override.
+- **`Requires=mariadb.service` failed the unit** on hosts using `mysql.service`
+  or a remote database. The unit is still ordered `After=` both, and
+  `Restart=on-failure` covers a slow database.
+- A stream socket the service user cannot open now reports that
+  `ZM_STREAM_SOCKET_GROUP` membership is missing, rather than a bare "permission
+  denied" naming nothing actionable.
+- `docs/tls.md` claimed the systemd unit uses `DynamicUser`; it runs as
+  `User=zoneminder`.
+
+### Changed
+- `packaging/install.sh` rewritten for source installs: it now matches the
+  package layout, installs the man pages and `zm_api-db`, and runs
+  `setup-instance.sh` to generate JWT keys. Previously it installed the unit to a
+  different directory than the packages, never generated keys, and left a
+  freshly "installed" service unable to sign a token.
+- Removed the dead `[package.metadata.rpm]` block from `Cargo.toml`; nothing
+  invoked cargo-rpm, and it duplicated `packaging/rpm/zm_api.spec`.
+
+## [3.0.0-alpha.1]
+
+First Rust release, replacing ZoneMinder's Perl/PHP/CGI API surface with a
+single native service. It talks directly to an existing ZoneMinder
+MySQL/MariaDB database and ships in **passive mode**, serving only the REST API
+so it can be installed alongside a running ZoneMinder without touching its
+daemons.
+
+### Added
+- **REST API** under `/api/v3` for monitors, events, frames, zones, groups,
+  users, storage, controls, PTZ presets, and configuration — with an
+  auto-generated OpenAPI 3 spec at `/api-docs/openapi.json` and Swagger UI at
+  `/swagger-ui`.
+- **Live streaming** over WebRTC and HLS, sourced from zmc's per-monitor stream
+  socket (video and audio on one connection with a HELLO codec handshake).
+- **Event playback** — VOD, fragmented-MP4 streaming, thumbnails, and motion
+  synopsis.
+- **Authentication and authorisation** — RS256 JWTs with separate access and
+  refresh key pairs, server-side revocation, feature-level RBAC, and row-level
+  monitor ACLs.
+- **Daemon supervision (takeover mode)** — an opt-in replacement for `zmdc.pl`
+  and `zmwatch.pl`, with `zm_api-takeover` to switch a host between modes
+  safely.
+- **Retention** — automatic recording cleanup bounded by free-space floor, age,
+  and per-storage quota, deleting media and database rows together.
+- **ONVIF** device discovery, media profiles, PTZ, and event pull-point.
+- **Natural-language event search** over MariaDB 11.8 native vectors.
+- **Object-detection registry** — CRUD over ZoneMinder 1.39's `AI_Datasets`,
+  `AI_Models`, and `AI_Object_Classes`, plus the per-monitor detection columns.
+- **Packaging** for Debian/Ubuntu (`.deb`), Fedora/RHEL/openSUSE (`.rpm`), and
+  Arch (`PKGBUILD`), with a systemd unit, per-install JWT key generation, and
+  built-in TLS/ACME.
+
+### Notes
+- Upgrading an existing ZoneMinder database requires
+  `zm_api-db bridge -u mysql://...` before first start. Only a fresh, empty
+  database should use `zm_api-db up`.
+- Passive mode is the default and the recommended arrangement; takeover is
+  opt-in.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,8 +209,16 @@ priority = "optional"
 maintainer-scripts = "packaging/debian"
 assets = [
   ["target/release/zm_api", "usr/bin/zm_api", "755"],
+  # Migration/upgrade tool. Built as `migrator` (the cargo bin name the parity
+  # scripts use) but installed under the zm_api- prefix: `migrator` is far too
+  # generic a name for /usr/bin.
+  ["target/release/migrator", "usr/bin/zm_api-db", "755"],
   ["packaging/zm_api-takeover.sh", "usr/bin/zm_api-takeover", "755"],
   ["packaging/setup-instance.sh", "usr/share/zm_api/setup-instance.sh", "755"],
+  ["packaging/man/zm_api.8", "usr/share/man/man8/zm_api.8", "644"],
+  ["packaging/man/zm_api-takeover.8", "usr/share/man/man8/zm_api-takeover.8", "644"],
+  ["packaging/man/zm_api-db.8", "usr/share/man/man8/zm_api-db.8", "644"],
+  ["packaging/man/zm_api.env.5", "usr/share/man/man5/zm_api.env.5", "644"],
   ["settings/base.toml", "etc/zm_api/base.toml", "644"],
   ["settings/prod.toml", "etc/zm_api/prod.toml", "644"],
   ["packaging/systemd/zm_api.env", "etc/zm_api/zm_api.env", "644"],
@@ -225,26 +233,6 @@ conf-files = [
   "/etc/zm_api/prod.toml",
   "/etc/zm_api/zm_api.env",
 ]
-
-[package.metadata.rpm]
-package = "zm-api"
-license = "AGPL-3.0-or-later"
-
-[package.metadata.rpm.cargo]
-buildflags = ["--release"]
-
-[package.metadata.rpm.targets]
-zm_api = { path = "/usr/bin/zm_api" }
-
-[package.metadata.rpm.files]
-"settings/base.toml" = { path = "/etc/zm_api/base.toml", mode = "644", config = true }
-"settings/prod.toml" = { path = "/etc/zm_api/prod.toml", mode = "644", config = true }
-"packaging/systemd/zm_api.env" = { path = "/etc/zm_api/zm_api.env", mode = "644", config = true }
-"packaging/systemd/zm_api.service" = { path = "/usr/lib/systemd/system/zm_api.service", mode = "644" }
-"packaging/zm_api-takeover.sh" = { path = "/usr/bin/zm_api-takeover", mode = "755" }
-"packaging/setup-instance.sh" = { path = "/usr/share/zm_api/setup-instance.sh", mode = "755" }
-# `static/` is intentionally NOT shipped — it holds dev JWT keys; packaged
-# installs generate their own in /var/lib/zm_api/keys.
 
 # Full DWARF debug info triples the linker's peak memory and pushes this dev
 # box (16 GiB / 4 GiB swap, with ZoneMinder + zm_api already resident) into

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 with live streaming, fine-grained access control, and OpenAPI docs baked in.*
 
 [![Tests](https://github.com/SteveGilvarry/zm-api/actions/workflows/test.yml/badge.svg)](https://github.com/SteveGilvarry/zm-api/actions/workflows/test.yml)
-![Coverage](https://img.shields.io/badge/coverage-59%25-green)
+![Coverage](https://img.shields.io/badge/coverage-62%25-green)
 ![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust&logoColor=white)
 ![Axum](https://img.shields.io/badge/Axum-0.8-blue)
 ![SeaORM](https://img.shields.io/badge/SeaORM-1.1-9cf)
@@ -29,8 +29,15 @@ sudo dpkg -i zm-api_*.deb        # Debian / Ubuntu / Raspberry Pi OS
 sudo dnf install zm-api-*.rpm    # Fedora / RHEL / Rocky / Alma  (zypper on openSUSE)
 ```
 
+**Already running ZoneMinder?** Migrate its database before the first start —
+`zm_api-db bridge -u mysql://zmuser:zmpass@localhost/zm`. Only a fresh, empty database
+should use `zm_api-db up`. See `man 8 zm_api-db`.
+
 Want to build from source or run a local dev setup instead? See **[Quick Start](#-quick-start)**.
+How the pieces fit together (ZoneMinder + zm_api + a dashboard, ports, serving the
+frontend): **[`docs/architecture.md`](docs/architecture.md)**.
 Full distro matrix, config & TLS: **[`docs/deployment.md`](docs/deployment.md)**.
+What changed: **[`CHANGELOG.md`](CHANGELOG.md)**.
 
 ---
 
@@ -43,7 +50,7 @@ PHP, and CGI over two decades. **zm_api** replaces that surface with one cohesiv
 - ⚡ **Fast & async** — built on Axum + Tokio; streaming endpoints don't block the API.
 - 🔒 **Secure by default** — JWT auth, per-feature RBAC, *and* row-level monitor ACLs.
 - 📖 **Self-documenting** — every endpoint is in an auto-generated OpenAPI spec + Swagger UI.
-- 🧪 **Actually tested** — ~600 unit + integration tests, with a coverage gate in CI.
+- 🧪 **Actually tested** — 1,100+ unit + integration tests, with a coverage gate in CI.
 - 🗄️ **Drop-in schema** — talks directly to an existing ZoneMinder MySQL/MariaDB database.
 
 ---
@@ -174,7 +181,7 @@ For development or platforms without a prebuilt package.
 git clone https://github.com/SteveGilvarry/zm-api.git
 cd zm-api
 
-# 2. Spin up a local test database (Docker / Apple Container)
+# 2. Spin up a local test database (Docker)
 ./scripts/db-manager.sh start
 ./scripts/db-manager.sh mysql      # load the ZoneMinder schema
 
@@ -230,7 +237,8 @@ cargo llvm-cov --all-features --ignore-filename-regex '/(entity|migration)/' \
 ```
 
 CI runs the suite on every push and **gates line coverage** — it can't regress below the
-floor. Currently **~59%** and climbing, ~600 tests across unit + per-domain integration files.
+floor. Currently **~62%** and climbing (the CI floor is 60%), across 1,100+ unit and per-domain
+integration tests — roughly 850 run without a database, the rest need one.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,8 @@ before relying on any specific phase verdict.
 
 | Doc | Scope |
 |---|---|
-| [deployment.md](deployment.md) | Packaging, profiles, passive/active mode, distro matrix, release flow. |
+| [architecture.md](architecture.md) | How ZoneMinder + zm_api + a dashboard fit together: what must share a host, serving the frontend (reverse proxy vs separate origins), ports, and the auth surface a frontend needs. |
+| [deployment.md](deployment.md) | Packaging, profiles, upgrading an existing ZM database, passive/active mode, distro matrix, release flow. |
 | [tls.md](tls.md) | Built-in TLS + ACMEv2 config and external certbot/lego flows. |
 
 ## Archive (kept for history)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,208 @@
+# How ZoneMinder, zm_api, and a dashboard fit together
+
+This describes the deployed system: which process owns what, what has to share a
+host, and how a browser frontend reaches the API. For install and packaging
+steps see [deployment.md](deployment.md); for TLS see [tls.md](tls.md).
+
+## The three components
+
+| Component | What it is | Owns |
+| --- | --- | --- |
+| **ZoneMinder** | The existing C++/Perl/PHP install | Capture daemons (`zmc`, `zma`), the `zm` database schema, the events directory, the legacy web UI |
+| **zm_api** | This project — one native binary | The REST API on port 8080, live streaming (WebRTC + HLS), event playback/VOD, retention |
+| **zm-dash** | A browser dashboard (separate project) | Nothing server-side — it is static files calling the API |
+
+zm_api does not replace ZoneMinder's capture pipeline. In the default
+configuration it does not manage ZoneMinder's processes at all; it reads and
+writes the same database, the same events directory, and the same shared memory
+that ZoneMinder itself uses, and adds an HTTP surface over them.
+
+## What must share a host
+
+This is the constraint that shapes every deployment: **zm_api must run on the
+same machine as `zmc`.**
+
+| Resource | Path | Access | Same host? |
+| --- | --- | --- | --- |
+| Database | `mysql://…` | read-write, including DDL at startup | **No** — may be remote |
+| `zm.conf` | `/etc/zm/zm.conf`, `/etc/zm/conf.d/*.conf` | read-only | Same host, or copy the file |
+| Events directory | `/var/lib/zoneminder/events` (per-event path from the `Storage` table) | read for playback, delete for retention | Same host, or a shared mount |
+| Stream sockets | `/run/zm/stream_{id}.sock` | connect + read | **Yes, mandatory** |
+| Shared memory | `/dev/shm/zm.mmap.{id}` | read-write | **Yes, mandatory** |
+| PTZ sockets | `/run/zm/zmcontrol-{id}.sock` | connect + write | Yes (for the Perl bridge) |
+
+Only the database is genuinely detachable. Live streaming reads zmc's unix
+sockets and alarm control writes ZoneMinder's shared memory, neither of which
+crosses a machine boundary.
+
+Two consequences worth stating plainly. The stream sockets are mode 0660 owned
+by ZoneMinder's `ZM_STREAM_SOCKET_GROUP`, so **the zm_api service user must be a
+member of that group** or every live stream fails with a permission error. And
+zm_api runs schema migrations against the shared ZoneMinder database at
+startup — see the upgrade section of [deployment.md](deployment.md) before
+first run on an existing install.
+
+## Passive and takeover mode
+
+zm_api ships **passive** (`daemon.enabled = false`) and most deployments should
+stay there.
+
+**Passive.** zm_api serves the REST API. `zoneminder.service` keeps supervising
+`zmdc.pl`, `zmc`, `zmfilter` and the rest, exactly as before zm_api was
+installed. Installing the package changes nothing about how ZoneMinder records.
+The daemon-control endpoints (`/api/v3/daemons*`, `/api/v3/system/*`) are still
+registered but return 503.
+
+**Takeover** (`daemon.enabled = true`). zm_api supervises the ZoneMinder daemons
+itself, replacing `zmdc.pl` and `zmwatch.pl` with its own manager and health
+loop.
+
+Exactly one supervisor may run. On startup in takeover mode zm_api runs
+`kill_orphan_daemons()`, which `pkill -9`s `zmc`, `zma`, `zmfilter.pl` and
+friends before starting its own — so leaving `zoneminder.service` enabled means
+two supervisors killing and restarting each other's processes. Use
+`zm_api-takeover`, which sequences both services correctly, rather than editing
+the flag by hand. See `man 8 zm_api-takeover`.
+
+## Serving the dashboard
+
+**zm_api serves no static files.** There is no `ServeDir`, no SPA fallback — any
+unmatched path returns a JSON 404, including `/index.html`. `APP_STATIC_DIR`
+despite its name is not an HTTP-served directory; it only locates JWT keys and a
+couple of image constants.
+
+So the dashboard is always served by something else, and there are two shapes:
+
+### Same origin behind a reverse proxy (recommended)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name zm.example.com;
+
+    # Dashboard: static build output. The SPA fallback lives here, because
+    # zm_api has none — see above.
+    root /var/www/zm-dash;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebRTC signalling (/api/v3/live/{id}/webrtc/ws) is a WebSocket.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # Media must stream, not accumulate: buffering stalls HLS and
+        # fragmented-MP4 playback.
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+    }
+
+    location /swagger-ui { proxy_pass http://127.0.0.1:8080; }
+    location /api-docs/  { proxy_pass http://127.0.0.1:8080; }
+}
+
+# Required for the Upgrade header above.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+```
+
+The browser makes no cross-origin request, so **CORS does not apply and
+`allowed_origins` needs nothing**. This is the deployment to recommend: one
+hostname, one certificate, one thing to get wrong.
+
+Since the proxy is trusted here, also set
+`APP_SERVER__MIDDLEWARE__TRUST_PROXY_HEADERS=true` so rate limits key on the
+real client IP rather than the proxy's — otherwise every client shares one
+bucket. Leave it `false` on any host where zm_api is reachable directly: the
+headers are attacker-controlled there, and trusting them lets a client mint a
+fresh bucket per request.
+
+### Separate origins
+
+The dashboard on `https://dash.example.com`, the API on `https://api.example.com`.
+Then CORS **is** in play and you must set:
+
+```
+APP_SERVER__ALLOWED_ORIGINS=https://dash.example.com
+```
+
+Unset, zm_api allows localhost only. The failure mode is quiet — the dashboard
+loads and every request fails, reported only in the browser console — so this is
+the single most likely day-one problem. zm_api logs its effective origin list at
+startup and warns when it fell back to the default; check there first.
+
+A bare `*` is not accepted. The API sends credentials, and the CORS spec forbids
+that pairing. Entries are exact origins, or `scheme://host:*` to match any port
+on a host (intended for development).
+
+## Ports
+
+| Port | What | When |
+| --- | --- | --- |
+| 8080 | The entire HTTP API, HLS, and WebRTC signalling | Always (`server.port`) |
+| 80 | ACME HTTP-01 challenge only | Only with `acme.challenge = "http-01"` |
+| ephemeral UDP | WebRTC media | Whenever WebRTC is used |
+
+One TCP listener, and it is HTTP **or** HTTPS, never both: enabling
+`server.tls` or `server.acme` switches that same port to TLS. Enabling both is a
+startup error. The default ACME challenge is `tls-alpn-01`, which opens no
+second port.
+
+The WebRTC UDP ports are OS-assigned ephemeral, with no configurable range —
+worth knowing before putting the media path through a firewall or NAT.
+
+## API surface
+
+Everything lives under `/api/v3`, plus `/swagger-ui` and
+`/api-docs/openapi.json`.
+
+Authentication is a bearer JWT and **no cookies are involved anywhere**:
+
+- `POST /api/v3/auth/login` → `{ token_type, access_token, refresh_token, expire_in }`
+- `POST /api/v3/auth/refresh` with `{ "token": "<refresh_token>" }`
+- `GET /api/v3/auth/logout` — revokes all of that user's outstanding tokens server-side
+- `GET /api/v3/me` — returns the user plus `issued_at`/`expires_at`, so a client never has to decode the JWT
+
+Send `Authorization: Bearer <token>`. Access tokens last 10 minutes and refresh
+tokens 1 hour, signed with separate RSA key pairs — a leaked access key cannot
+mint refresh tokens.
+
+The one exception to the header rule is media: the snapshot route also accepts
+`?token=<JWT>`, because `<img>` and `<video>` elements cannot set headers.
+
+`GET /api/v3/server/health_check` and `GET /api/v3/host/getVersion` are public
+and unauthenticated — useful as proxy health checks.
+
+Two things a frontend author should know up front.
+
+**Rate limits.** The authentication endpoints have their own limiter, on by
+default at roughly one request per two seconds with a burst of 10 — a login
+retry loop will start getting 429s. The `prod` profile additionally enables a
+global per-IP limiter that is off in `base.toml`, so a dashboard that fans out
+many parallel requests on page load can behave differently in production than in
+development. Behind a reverse proxy, set
+`APP_SERVER__MIDDLEWARE__TRUST_PROXY_HEADERS=true` or every client shares the
+proxy's single bucket.
+
+**Authorisation.** Every non-auth route is behind feature-level RBAC, with reads
+requiring View and writes requiring Edit on the relevant feature; daemon, system,
+and permission-management routes require the admin-tier `System` feature. On top
+of that, monitor and group rows are filtered per user, so two accounts can get
+different results from the same endpoint.
+
+## Startup order
+
+Nothing enforces ordering between the two services, and nothing needs to: zm_api
+retries, and systemd restarts it on failure. The unit is ordered `After=`
+mariadb/mysql but deliberately does **not** `Requires=` them, so a host using a
+remote database or `mysql.service` still starts.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,10 @@
 # Deployment and Packaging Guide
 
+For how ZoneMinder, zm_api, and a dashboard fit together as a system — what has
+to share a host, how to serve the frontend, ports, and the auth surface — see
+[architecture.md](architecture.md). This document covers installing and
+packaging.
+
 ## Environments
 - dev: local developer runs with `APP_PROFILE=dev`, uses local `settings/`.
 - staging: production-like config, separate database, limited access.
@@ -15,6 +20,31 @@
   the `secret.*_key` paths in the profile config.
 - Generate per-install JWT keys with `scripts/generate-jwt-keys.sh /var/lib/zm_api/keys`
   (or `JWT_KEY_DIR=/var/lib/zm_api/keys`).
+
+## Upgrading an existing ZoneMinder database
+
+**This is the step most likely to be skipped, and it fails quietly.** zm_api runs
+pending migrations at startup but only *warns* if they fail, so a database left in
+the wrong state yields a service that starts, answers requests, and has features
+silently missing.
+
+There are two distinct cases and they need different commands:
+
+| Database | Command |
+| --- | --- |
+| Existing ZoneMinder (1.26.0+) | `zm_api-db bridge -u mysql://zmuser:zmpass@localhost/zm` |
+| Fresh / empty | `zm_api-db up -u mysql://...` |
+
+`bridge` walks the embedded `zm_update` chain, converges triggers, stamps the
+baseline migration as applied, then runs the rest. `up` assumes it is *creating*
+the schema — never run it against a database that already has ZoneMinder tables.
+
+Back up first (`bridge` rewrites schema across many ZoneMinder versions in one
+pass and has no undo), and check the result with `zm_api-db status`. Full details
+in `man 8 zm_api-db`.
+
+> The tool is built by cargo as `migrator` (the name `scripts/*-parity.sh` use)
+> and installed as `/usr/bin/zm_api-db`.
 
 ## Passive vs. active (daemon control)
 zm_api ships **passive** by default (`daemon.enabled = false`): it serves only the
@@ -40,15 +70,26 @@ Equivalent manual steps: `systemctl disable --now zoneminder`, set
 2. Confirm DB connectivity — zm_api falls back to `/etc/zm/zm.conf` when the
    `[db]` placeholders are unchanged; otherwise set `APP_DB__*` in `zm_api.env`.
 3. Configure TLS/ACME if needed (see `docs/tls.md`).
-4. Validate health with `/swagger-ui` and a smoke test against `/api-docs/openapi.json`.
-5. When ready, run `sudo zm_api-takeover` to assume daemon supervision.
+4. If a dashboard will be served from a different origin than the API, set
+   `APP_SERVER__ALLOWED_ORIGINS` to that origin. Skipping this is the most
+   common day-one failure: the dashboard loads and every request is
+   CORS-blocked, visible only in the browser console. Not needed when both sit
+   behind one hostname — see [architecture.md](architecture.md).
+5. Add the service user to ZoneMinder's `ZM_STREAM_SOCKET_GROUP` if it is not
+   `zoneminder`, or live streaming fails on socket permissions:
+   `systemctl edit zm_api` → `[Service]` → `SupplementaryGroups=<group>`.
+6. Validate health with `/swagger-ui` and a smoke test against `/api-docs/openapi.json`.
+7. When ready, run `sudo zm_api-takeover` to assume daemon supervision
+   (prerequisites, verification, and rollback: `man 8 zm_api-takeover`).
 
 JWT keys are generated automatically on install by `setup-instance.sh`. For a
 manual/source install, run `scripts/generate-jwt-keys.sh /var/lib/zm_api/keys`
 and point `secret.*_key` (or `APP_SECRET__*`) at that directory.
 
 ## Packaging layout
-- Binary: `/usr/bin/zm_api`; takeover helper: `/usr/bin/zm_api-takeover`
+- Binary: `/usr/bin/zm_api`; takeover helper: `/usr/bin/zm_api-takeover`;
+  migration tool: `/usr/bin/zm_api-db`
+- Man pages: `zm_api(8)`, `zm_api-takeover(8)`, `zm_api-db(8)`, `zm_api.env(5)`
 - Config: `/etc/zm_api/base.toml`, `/etc/zm_api/prod.toml`, `/etc/zm_api/zm_api.env`
 - State (JWT keys): `/var/lib/zm_api/keys` (generated per-install; never packaged)
 - Setup helper: `/usr/share/zm_api/setup-instance.sh`

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -74,6 +74,7 @@ systemctl restart zm_api
 - `server.acme.enabled` and `server.tls.enabled` are mutually exclusive.
 - HTTP-01 mode starts a separate listener on `server.acme.http_port` for challenges.
 - `server.acme.cache_dir` must be writable by the service user.
-- The systemd unit uses `DynamicUser` with `SupplementaryGroups=ssl-cert`. Ensure the
-  cert/key are readable by the `ssl-cert` group (for example with `setfacl`) or
-  switch the unit to a static `User=`/`Group=` if you prefer fixed ownership.
+- The systemd unit runs as `User=zoneminder` / `Group=zoneminder` with
+  `SupplementaryGroups=video ssl-cert`. Ensure the cert/key are readable by the
+  `ssl-cert` group — for example `setfacl -m g:ssl-cert:rx /etc/letsencrypt/{live,archive}`
+  — or chown them to `zoneminder` if you prefer fixed ownership.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -38,12 +38,18 @@ build() {
 package() {
   cd "${_srcdir}"
   install -Dm755 "target/release/${_appname}"         "${pkgdir}/usr/bin/${_appname}"
+  # Built as `migrator`; installed prefixed, that name is too generic for /usr/bin.
+  install -Dm755 target/release/migrator               "${pkgdir}/usr/bin/${_appname}-db"
   install -Dm755 packaging/zm_api-takeover.sh          "${pkgdir}/usr/bin/${_appname}-takeover"
   install -Dm755 packaging/setup-instance.sh           "${pkgdir}/usr/share/${_appname}/setup-instance.sh"
   install -Dm644 settings/base.toml                    "${pkgdir}/etc/${_appname}/base.toml"
   install -Dm644 settings/prod.toml                    "${pkgdir}/etc/${_appname}/prod.toml"
   install -Dm644 packaging/systemd/zm_api.env          "${pkgdir}/etc/${_appname}/zm_api.env"
   install -Dm644 packaging/systemd/zm_api.service      "${pkgdir}/usr/lib/systemd/system/${_appname}.service"
+  install -Dm644 packaging/man/zm_api.8                 "${pkgdir}/usr/share/man/man8/${_appname}.8"
+  install -Dm644 packaging/man/zm_api-takeover.8       "${pkgdir}/usr/share/man/man8/${_appname}-takeover.8"
+  install -Dm644 packaging/man/zm_api-db.8             "${pkgdir}/usr/share/man/man8/${_appname}-db.8"
+  install -Dm644 packaging/man/zm_api.env.5            "${pkgdir}/usr/share/man/man5/zm_api.env.5"
   install -Dm644 LICENSE                               "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
   # static/ is not packaged — it holds dev JWT keys; per-install keys are
   # generated into /var/lib/zm_api/keys by setup-instance.sh.

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,116 +1,95 @@
-#!/bin/bash
-# ZM API Installation Script
-# Creates user, directories, and installs systemd service
+#!/usr/bin/env bash
+#
+# install.sh — install zm_api from a source build.
+#
+# For when no distribution package is available (or you are testing a local
+# build). Lays files out exactly where the .deb/.rpm/PKGBUILD put them, so a
+# later package install upgrades cleanly instead of colliding.
+#
+# If a package IS available for your distribution, use it instead — it also
+# handles upgrades, removal, and dependencies. See docs/deployment.md.
+#
+# Usage:
+#   cargo build --release --bins
+#   sudo ./packaging/install.sh
+#
+set -euo pipefail
 
-set -e
-
-# Configuration
-ZM_USER="zoneminder"
-ZM_GROUP="zoneminder"
-ZM_HOME="/var/lib/zoneminder"
-ZM_EVENTS="/var/cache/zoneminder/events"
-ZM_IMAGES="/var/cache/zoneminder/images"
-ZM_TEMP="/var/cache/zoneminder/temp"
-ZM_RUN="/run/zm"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONFIG_DIR="/etc/zm_api"
-STATIC_DIR="/usr/share/zm_api/static"
-BIN_PATH="/usr/bin/zm_api"
+UNIT_DIR="/lib/systemd/system"
+MAN_DIR="/usr/share/man"
 
-echo "=== ZM API Installation ==="
-
-# Check if running as root
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root"
-   exit 1
+  echo "This script must be run as root (try: sudo $0)" >&2
+  exit 1
 fi
 
-# Create zoneminder group if it doesn't exist
-if ! getent group "$ZM_GROUP" > /dev/null 2>&1; then
-    echo "Creating group: $ZM_GROUP"
-    groupadd --system "$ZM_GROUP"
+# Match the packages: unit files under /lib on Debian-likes, /usr/lib elsewhere.
+[[ -d /lib/systemd/system ]] || UNIT_DIR="/usr/lib/systemd/system"
+
+release="${REPO_ROOT}/target/release"
+if [[ ! -x "${release}/zm_api" ]]; then
+  echo "error: ${release}/zm_api not found — run 'cargo build --release --bins' first" >&2
+  exit 1
 fi
 
-# Create zoneminder user if it doesn't exist
-if ! id "$ZM_USER" > /dev/null 2>&1; then
-    echo "Creating user: $ZM_USER"
-    useradd --system \
-        --gid "$ZM_GROUP" \
-        --groups video \
-        --home-dir "$ZM_HOME" \
-        --shell /usr/sbin/nologin \
-        --comment "ZoneMinder Daemon" \
-        "$ZM_USER"
-fi
+echo "Installing binaries..."
+install -D -m 0755 "${release}/zm_api"                  /usr/bin/zm_api
+install -D -m 0755 "${release}/migrator"                /usr/bin/zm_api-db
+install -D -m 0755 "${REPO_ROOT}/packaging/zm_api-takeover.sh" /usr/bin/zm_api-takeover
+install -D -m 0755 "${REPO_ROOT}/packaging/setup-instance.sh"  /usr/share/zm_api/setup-instance.sh
 
-# Add user to video group (for camera access)
-echo "Adding $ZM_USER to video group"
-usermod -aG video "$ZM_USER"
+echo "Installing man pages..."
+install -D -m 0644 "${REPO_ROOT}/packaging/man/zm_api.8"          "${MAN_DIR}/man8/zm_api.8"
+install -D -m 0644 "${REPO_ROOT}/packaging/man/zm_api-takeover.8" "${MAN_DIR}/man8/zm_api-takeover.8"
+install -D -m 0644 "${REPO_ROOT}/packaging/man/zm_api-db.8"       "${MAN_DIR}/man8/zm_api-db.8"
+install -D -m 0644 "${REPO_ROOT}/packaging/man/zm_api.env.5"      "${MAN_DIR}/man5/zm_api.env.5"
 
-# Create directories
-echo "Creating directories..."
-mkdir -p "$ZM_HOME"
-mkdir -p "$ZM_EVENTS"
-mkdir -p "$ZM_IMAGES"
-mkdir -p "$ZM_TEMP"
-mkdir -p "$CONFIG_DIR"
-mkdir -p "$STATIC_DIR"
+echo "Installing systemd unit..."
+install -D -m 0644 "${REPO_ROOT}/packaging/systemd/zm_api.service" "${UNIT_DIR}/zm_api.service"
 
-# Set ownership
-echo "Setting directory ownership..."
-chown -R "$ZM_USER:$ZM_GROUP" "$ZM_HOME"
-chown -R "$ZM_USER:$ZM_GROUP" "$ZM_EVENTS"
-chown -R "$ZM_USER:$ZM_GROUP" "$ZM_IMAGES"
-chown -R "$ZM_USER:$ZM_GROUP" "$ZM_TEMP"
-chown -R "$ZM_USER:$ZM_GROUP" "$CONFIG_DIR"
-chown -R "$ZM_USER:$ZM_GROUP" "$STATIC_DIR"
+# Config files are never overwritten: local edits outlive a reinstall. base.toml
+# is the exception — it is the packaged defaults layer and is meant to be
+# replaced, with local changes belonging in prod.toml or zm_api.env.
+echo "Installing configuration..."
+install -D -m 0644 "${REPO_ROOT}/settings/base.toml" "${CONFIG_DIR}/base.toml"
+for f in prod.toml:settings/prod.toml zm_api.env:packaging/systemd/zm_api.env; do
+  dest="${CONFIG_DIR}/${f%%:*}"
+  src="${REPO_ROOT}/${f##*:}"
+  if [[ -e "$dest" ]]; then
+    echo "  keeping existing $dest"
+  else
+    install -D -m 0644 "$src" "$dest"
+  fi
+done
 
-# Set permissions
-chmod 755 "$ZM_HOME"
-chmod 755 "$ZM_EVENTS"
-chmod 755 "$ZM_IMAGES"
-chmod 755 "$ZM_TEMP"
-chmod 750 "$CONFIG_DIR"
+# Creates the service account, /var/lib/zm_api/keys, and the JWT keys. Without
+# this the service starts and immediately fails to sign tokens.
+echo "Provisioning instance (user, state dirs, JWT keys)..."
+/usr/share/zm_api/setup-instance.sh
 
-# Install binary (if provided as argument or in current directory)
-if [[ -f "${1:-./target/release/zm_api}" ]]; then
-    echo "Installing binary to $BIN_PATH"
-    cp "${1:-./target/release/zm_api}" "$BIN_PATH"
-    chmod 755 "$BIN_PATH"
-else
-    echo "Note: Binary not found. Copy zm_api to $BIN_PATH manually."
-fi
-
-# Install systemd service
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -f "$SCRIPT_DIR/systemd/zm_api.service" ]]; then
-    echo "Installing systemd service..."
-    cp "$SCRIPT_DIR/systemd/zm_api.service" /etc/systemd/system/
-fi
-
-# Install environment file (if not exists, to preserve local changes)
-if [[ ! -f "$CONFIG_DIR/zm_api.env" ]] && [[ -f "$SCRIPT_DIR/systemd/zm_api.env" ]]; then
-    echo "Installing environment file..."
-    cp "$SCRIPT_DIR/systemd/zm_api.env" "$CONFIG_DIR/"
-    chown "$ZM_USER:$ZM_GROUP" "$CONFIG_DIR/zm_api.env"
-    chmod 640 "$CONFIG_DIR/zm_api.env"
-else
-    echo "Note: $CONFIG_DIR/zm_api.env exists, not overwriting."
-fi
-
-# Reload systemd
-echo "Reloading systemd..."
 systemctl daemon-reload
 
-echo ""
-echo "=== Installation Complete ==="
-echo ""
-echo "Next steps:"
-echo "  1. Configure database connection in $CONFIG_DIR/zm_api.env"
-echo "  2. Copy configuration files to $CONFIG_DIR/"
-echo "  3. Enable and start the service:"
-echo "     sudo systemctl enable zm_api"
-echo "     sudo systemctl start zm_api"
-echo ""
-echo "  Check status with:"
-echo "     sudo systemctl status zm_api"
-echo "     sudo journalctl -u zm_api -f"
+cat <<EOF
+
+=== Installation complete ===
+
+zm_api is installed in passive mode: it serves the REST API and leaves
+ZoneMinder's daemons alone.
+
+Next steps:
+  1. Database — zm_api reads /etc/zm/zm.conf automatically. Override in
+     ${CONFIG_DIR}/zm_api.env only if the database is elsewhere.
+  2. Existing ZoneMinder database? Migrate it before first start:
+       zm_api-db bridge -u mysql://zmuser:zmpass@localhost/zm
+     A fresh, empty database instead: zm_api-db up -u mysql://...
+  3. Serving a dashboard from another origin? Set APP_SERVER__ALLOWED_ORIGINS
+     in ${CONFIG_DIR}/zm_api.env, or the browser will block every request.
+  4. Start it:
+       systemctl enable --now zm_api
+       systemctl status zm_api
+       journalctl -u zm_api -f
+
+See man 8 zm_api, man 5 zm_api.env, and docs/deployment.md.
+EOF

--- a/packaging/man/zm_api-db.8
+++ b/packaging/man/zm_api-db.8
@@ -1,0 +1,103 @@
+.TH ZM_API-DB 8 "2026-08-22" "zm_api" "System Administration"
+.SH NAME
+zm_api\-db \- database migration and upgrade tool for zm_api
+.SH SYNOPSIS
+.B zm_api-db
+.B bridge
+.BI \-u " URL"
+.br
+.B zm_api-db
+.B up
+.RB [ \-u
+.IR URL ]
+.br
+.B zm_api-db
+.B status
+.RB [ \-u
+.IR URL ]
+.SH DESCRIPTION
+Applies
+.BR zm_api (8)'s
+own schema migrations. Which command you want depends entirely on whether the
+database already contains a ZoneMinder installation.
+.PP
+.B zm_api
+also runs pending migrations itself at startup. It logs a warning rather than
+refusing to start when they fail, so a database left in the wrong state
+produces a service that looks healthy but has features silently missing. Run
+this tool explicitly when upgrading, and read its output.
+.SH COMMANDS
+.TP
+.B bridge
+.B For an existing ZoneMinder database
+(1.26.0 or newer). Walks the embedded
+.I zm_update
+chain to bring the schema up to the version zm_api expects, converges triggers,
+stamps the baseline migration as already applied, then runs any remaining
+migrations.
+.IP
+This is the upgrade path from a stock ZoneMinder install, and the only correct
+first command for a database that has ZoneMinder tables in it.
+.TP
+.B up
+.B For a fresh, empty database only.
+Applies the baseline migration and everything after it.
+.IP
+Do not run this against an existing ZoneMinder database: the baseline assumes
+it is creating the schema, not adopting one. Use
+.B bridge
+there instead.
+.TP
+.B status
+List migrations and whether each has been applied. Read-only; safe at any time.
+.PP
+The underlying SeaORM CLI accepts further subcommands
+.RB ( down ", " fresh ", " refresh ", " reset ).
+They exist for development and will drop data; none is part of a supported
+upgrade.
+.SH OPTIONS
+.TP
+.BI \-u " URL" "\fR, \fP" \-\-database\-url " URL"
+Database connection URL, for example
+.IR mysql://zmuser:zmpass@localhost/zm .
+Falls back to the
+.B DATABASE_URL
+environment variable; the tool exits with status 2 if neither is given.
+.SH EXAMPLES
+Upgrade an existing ZoneMinder database, having taken a backup first:
+.PP
+.RS 4
+.EX
+mysqldump --single-transaction --routines --triggers zm > zm-backup.sql
+sudo systemctl stop zm_api
+zm_api-db bridge -u mysql://zmuser:zmpass@localhost/zm
+sudo systemctl start zm_api
+.EE
+.RE
+.PP
+Check what has been applied:
+.PP
+.RS 4
+.EX
+zm_api-db status -u mysql://zmuser:zmpass@localhost/zm
+.EE
+.RE
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Could not connect, or the migration failed.
+.TP
+.B 2
+No database URL supplied.
+.SH CAVEATS
+Take a database backup before
+.BR bridge .
+It rewrites schema across many ZoneMinder versions in one pass and has no
+undo.
+.SH SEE ALSO
+.BR zm_api (8),
+.BR zm_api.env (5),
+.BR mysqldump (1)

--- a/packaging/man/zm_api-takeover.8
+++ b/packaging/man/zm_api-takeover.8
@@ -1,0 +1,130 @@
+.TH ZM_API-TAKEOVER 8 "2026-08-22" "zm_api" "System Administration"
+.SH NAME
+zm_api\-takeover \- switch zm_api between passive and active daemon control
+.SH SYNOPSIS
+.B zm_api-takeover
+.RI [ \-\-yes ]
+.br
+.B zm_api-takeover \-\-revert
+.RI [ \-\-yes ]
+.SH DESCRIPTION
+Moves a ZoneMinder host between two supervision arrangements, sequencing both
+services so they are never both in charge.
+.PP
+After installation
+.BR zm_api (8)
+is
+.BR passive :
+it serves the REST API and leaves ZoneMinder's daemons alone, so it coexists
+with a running
+.BR zoneminder.service .
+.PP
+In
+.B active
+(takeover) mode zm_api supervises
+.BR zmc ,
+.BR zmfilter ,
+and the rest itself. Exactly one supervisor may run: two would fight over the
+same processes and shared memory segments, producing daemons that restart in a
+loop and events that record erratically. This script therefore stops and
+disables
+.B zoneminder.service
+before it flips zm_api's mode, and reverses that order on the way back.
+.PP
+Concretely, taking over: disable and stop
+.BR zoneminder.service ,
+set
+.B APP_DAEMON__ENABLED=true
+in the environment file, restart
+.BR zm_api.service .
+Reverting: set
+.B APP_DAEMON__ENABLED=false
+and restart zm_api first \(em releasing the daemons \(em then enable and start
+.BR zoneminder.service .
+.SH OPTIONS
+.TP
+.BR \-\-revert ", " \-\-passive
+Hand daemon control back to ZoneMinder.
+.TP
+.BR \-\-yes ", " \-y
+Skip the confirmation prompt. Intended for automation.
+.TP
+.BR \-h ", " \-\-help
+Print usage and exit.
+.SH PREREQUISITES
+.IP \(bu 2
+Run as root.
+.IP \(bu 2
+zm_api must already be working in passive mode. Takeover is not a way to fix a
+broken install: if the API cannot reach the database, taking over ZoneMinder's
+daemons as well means nothing records.
+.IP \(bu 2
+The service user needs write access to the ZoneMinder events directory, and
+membership of ZoneMinder's
+.B ZM_STREAM_SOCKET_GROUP
+for live streaming.
+.IP \(bu 2
+Nothing else may be starting the ZoneMinder daemons \(em no cron entry, no
+.BR zmpkg.pl
+invocation, no second host sharing the database with the same server ID.
+.SH VERIFYING
+After takeover, confirm that the daemons are running and that zm_api owns
+them:
+.PP
+.RS 4
+.EX
+systemctl is-active zm_api          # expect: active
+systemctl is-enabled zoneminder     # expect: disabled (or "not-found")
+ps -o ppid=,cmd= -C zmc             # expect: one zmc per enabled monitor,
+                                    #         parented by the zm_api process
+journalctl -u zm_api -n 50
+.EE
+.RE
+.PP
+Then confirm recording actually continues: watch the event count for an active
+monitor rise over a few minutes. A clean
+.B systemctl status
+proves the supervisor started, not that video is being captured.
+.SH REVERTING
+.PP
+.RS 4
+.EX
+sudo zm_api-takeover --revert
+.EE
+.RE
+.PP
+Reverting is the first thing to try if capture misbehaves after a takeover: it
+restores the arrangement the host had before, and the REST API keeps working
+throughout because passive mode is its normal state. If the script cannot run,
+the manual equivalent is to set
+.B APP_DAEMON__ENABLED=false
+in
+.IR /etc/zm_api/zm_api.env ,
+.BR "systemctl restart zm_api" ,
+then
+.BR "systemctl enable --now zoneminder" .
+.SH ENVIRONMENT
+.TP
+.B ZM_API_ENV_FILE
+Path to the environment file to edit. Default
+.IR /etc/zm_api/zm_api.env .
+.SH EXIT STATUS
+.TP
+.B 0
+Success, including a user-declined confirmation.
+.TP
+.B 1
+Not run as root, or the environment file does not exist.
+.TP
+.B 2
+Unrecognised argument.
+.SH FILES
+.TP
+.I /etc/zm_api/zm_api.env
+Edited in place to set
+.BR APP_DAEMON__ENABLED .
+.SH SEE ALSO
+.BR zm_api (8),
+.BR zm_api.env (5),
+.BR zmdc.pl (8),
+.BR zmpkg.pl (8)

--- a/packaging/man/zm_api.8
+++ b/packaging/man/zm_api.8
@@ -1,0 +1,157 @@
+.TH ZM_API 8 "2026-08-22" "zm_api" "System Administration"
+.SH NAME
+zm_api \- REST API server for a ZoneMinder installation
+.SH SYNOPSIS
+.B zm_api
+.RI [ OPTIONS ]
+.SH DESCRIPTION
+.B zm_api
+serves a versioned HTTP REST API over an existing ZoneMinder installation:
+monitors, events, zones, users, live streaming (WebRTC and HLS), PTZ control,
+and recording retention. It is a single native binary with no PHP, CGI, or Perl
+runtime of its own.
+.PP
+It runs in one of two modes.
+.TP
+.B Passive
+.RB ( daemon.enabled " = " false ,
+the default) \(em
+.B zm_api
+serves the REST API only. It does not create the daemon manager, bind
+.IR /run/zm/zmdc.sock ,
+or reap orphaned daemons, so it is safe to install alongside a running stock
+ZoneMinder:
+.B zoneminder.service
+keeps supervising
+.BR zmdc.pl ,
+.BR zmc ,
+and
+.BR zmfilter .
+.TP
+.B Active (takeover)
+.RB ( daemon.enabled " = " true )
+\(em
+.B zm_api
+supervises the ZoneMinder daemons itself.
+.B zoneminder.service
+must be stopped and disabled first, or the two supervisors fight over the same
+processes and shared memory. Use
+.BR zm_api-takeover (8)
+to switch modes; it performs both halves in the right order.
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print a usage summary and exit.
+.TP
+.BR \-V ", " \-\-version
+Print the version and exit.
+.TP
+.B \-\-openapi
+Write the OpenAPI 3 specification to standard output and exit. The same
+document served at
+.IR /api-docs/openapi.json ,
+without needing a running server \(em useful for diffing the API surface
+between releases or feeding a client generator.
+.PP
+There are no other arguments. All configuration comes from files and
+environment variables, and these options are handled before any of it is
+loaded, so they still work when the configuration is broken.
+.SH CONFIGURATION
+Sources are applied in order, each overriding the previous:
+.IP 1. 4
+ZoneMinder's
+.I /etc/zm/zm.conf
+and
+.IR /etc/zm/conf.d/*.conf ,
+used as a fallback for database settings only. This is what lets a packaged
+install work against an existing ZoneMinder without being told anything.
+.IP 2. 4
+.IR "<config dir>" /base.toml
+\(em the packaged defaults layer. Do not edit; it is replaced on upgrade.
+.IP 3. 4
+.IR "<config dir>" /{APP_PROFILE}.toml
+\(em for example
+.IR prod.toml .
+.IP 4. 4
+.B APP_*
+environment variables, from
+.I /etc/zm_api/zm_api.env
+in a packaged install.
+.PP
+The config directory is
+.B $APP_CONFIG_DIR
+if set, otherwise
+.I ./settings
+relative to the working directory. Nested keys use a double underscore:
+.B APP_DB__HOST=10.0.0.5
+sets
+.IR db.host .
+See
+.BR zm_api.env (5)
+for the variables.
+.SH ENDPOINTS
+.TP
+.I /api/v3/...
+The REST API.
+.TP
+.I /api-docs/openapi.json
+The OpenAPI 3 specification for every route the running binary serves.
+.TP
+.I /swagger-ui
+Interactive API browser. Useful as a first smoke test after install.
+.PP
+Authentication is a bearer JWT: obtain access and refresh tokens from the login
+endpoint and send
+.BR "Authorization: Bearer <token>" .
+Access and refresh tokens are signed with separate RSA key pairs and are not
+interchangeable.
+.SH FILES
+.TP
+.I /etc/zm_api/base.toml
+Packaged defaults. Replaced on upgrade.
+.TP
+.I /etc/zm_api/prod.toml
+Profile configuration. Safe to edit.
+.TP
+.I /etc/zm_api/zm_api.env
+Environment overrides read by the systemd unit. Safe to edit; see
+.BR zm_api.env (5).
+.TP
+.I /var/lib/zm_api/keys/
+JWT signing keys, generated per install and never packaged.
+.TP
+.I /var/log/zm_api/
+Log files.
+.TP
+.I /run/zm/zmdc.sock
+Daemon-control socket. Bound only in takeover mode.
+.TP
+.I /usr/share/zm_api/static/
+Static assets.
+.SH DIAGNOSTICS
+.TP
+.B "CORS allowed origins not configured"
+A browser dashboard served from any origin other than localhost will be
+blocked, and the browser reports it only in its own console. Set
+.B APP_SERVER__ALLOWED_ORIGINS
+to the dashboard's origin.
+.TP
+.B "permission denied opening stream socket"
+The service user is not a member of ZoneMinder's
+.BR ZM_STREAM_SOCKET_GROUP .
+The per-monitor stream sockets are mode 0660; add the group with
+.B systemctl edit zm_api
+and a
+.B SupplementaryGroups=
+line.
+.SH SEE ALSO
+.BR zm_api.env (5),
+.BR zm_api-takeover (8),
+.BR zmpkg.pl (8),
+.BR zmdc.pl (8)
+.PP
+.UR https://github.com/SteveGilvarry/zm-api
+Project documentation
+.UE
+.SH AUTHOR
+Steve Gilvarry and contributors.

--- a/packaging/man/zm_api.env.5
+++ b/packaging/man/zm_api.env.5
@@ -1,0 +1,214 @@
+.TH ZM_API.ENV 5 "2026-08-22" "zm_api" "File Formats"
+.SH NAME
+zm_api.env \- environment configuration for the zm_api service
+.SH SYNOPSIS
+.I /etc/zm_api/zm_api.env
+.SH DESCRIPTION
+A systemd
+.B EnvironmentFile
+read by
+.BR zm_api (8).
+Each line is
+.IR KEY = VALUE ;
+lines beginning with
+.B #
+are comments. Values are not shell-expanded and must not be quoted unless the
+quotes are part of the value.
+.PP
+This file is the last configuration layer applied, so anything set here
+overrides both
+.I base.toml
+and the profile TOML. That makes it the right place for host-specific
+settings \(em and a trap: a stale value here silently wins over a corrected
+default shipped by a later package upgrade.
+.PP
+Every setting in the TOML files can be overridden here. The variable name is
+.BR APP_ ,
+then the TOML path in upper case with
+.B __
+(two underscores) between levels:
+.I db.host
+becomes
+.BR APP_DB__HOST ,
+.I server.middleware.body_limit_bytes
+becomes
+.BR APP_SERVER__MIDDLEWARE__BODY_LIMIT_BYTES .
+Restart the service after editing.
+.SH CORE VARIABLES
+.TP
+.B APP_PROFILE
+Which profile TOML to load:
+.BR dev ", " test ", " test-db ", or " prod .
+Packaged installs use
+.BR prod .
+.TP
+.B APP_CONFIG_DIR
+Directory holding
+.I base.toml
+and the profile TOML. Packaged:
+.IR /etc/zm_api .
+.TP
+.B APP_STATIC_DIR
+Directory holding static assets. Packaged:
+.IR /usr/share/zm_api/static .
+.TP
+.B APP_LOG_DIR
+Directory for log files. Packaged:
+.IR /var/log/zm_api .
+.TP
+.B RUST_LOG
+Log filter. Either a bare level
+.RB ( error ", " warn ", " info ", " debug ", " trace )
+or per-module directives, e.g.
+.BR "info,zm_api::streaming=debug" .
+Default:
+.BR info .
+.SH NETWORK AND BROWSER ACCESS
+.TP
+.B APP_SERVER__ADDR
+Bind address. Default
+.BR 0.0.0.0 .
+.TP
+.B APP_SERVER__PORT
+Bind port.
+.TP
+.B APP_SERVER__ALLOWED_ORIGINS
+Comma-separated list of browser origins permitted to call the API (CORS).
+.B Required whenever a dashboard is served from an origin other than
+.BR localhost .
+.IP
+Each entry is an exact origin
+.RB ( https://zm.example.com )
+or a host with a
+.B :*
+port wildcard
+.RB ( http://localhost:* ),
+which matches that host on any port. A bare
+.B *
+is not accepted: the API sends credentials, and the CORS specification forbids
+that pairing \(em browsers reject it.
+.IP
+Unset means localhost only. When the dashboard and the API share one hostname
+behind a reverse proxy, the browser makes no cross-origin request and this
+setting does not apply.
+.IP
+The failure mode is quiet: the browser reports the block in its own console,
+and the API logs nothing unusual. If a dashboard loads but every request fails,
+check this first \(em and check the service log at startup, which names the
+effective origin list and warns when it fell back to the default.
+.IP
+An un-prefixed
+.B ALLOWED_ORIGINS
+is still honoured for compatibility with pre-3.0 deployments, but is
+deprecated and logs a warning.
+.SH DATABASE
+.TP
+.BR APP_DB__HOST ", " APP_DB__PORT ", " APP_DB__USERNAME ", " APP_DB__PASSWORD ", " APP_DB__DATABASE_NAME
+Connection settings. When left at the packaged placeholders, zm_api falls back
+to ZoneMinder's own
+.I /etc/zm/zm.conf
+\(em so on a normal single-host install there is nothing to set here.
+.SH DAEMON CONTROL
+.TP
+.B APP_DAEMON__ENABLED
+.B false
+(default) is passive mode: REST API only, ZoneMinder's own daemons untouched.
+.B true
+is takeover mode, valid only once
+.B zoneminder.service
+is stopped and disabled. Prefer
+.BR zm_api-takeover (8)
+over editing this by hand; it sequences both services correctly.
+.TP
+.B APP_DAEMON__BIN_PATH
+Directory holding ZoneMinder's compiled binaries
+.RB ( zmc ", " zma ).
+Default
+.IR /usr/bin .
+.TP
+.B APP_DAEMON__SCRIPT_PATH
+Directory holding ZoneMinder's Perl scripts
+.RB ( zmdc.pl ", " zmfilter.pl ).
+Normally leave unset: distributions disagree
+.RI ( /usr/bin
+on Debian and Ubuntu,
+.I /usr/share/zoneminder/scripts
+on the RPM distributions) and zm_api searches the standard locations
+automatically. Set it only to override that search.
+.TP
+.BR APP_DAEMON__SOCKET_PATH ", " APP_DAEMON__SOCKET_NAME
+Location of the daemon-control socket. Default
+.IR /run/zm/zmdc.sock .
+.TP
+.BR APP_DAEMON__ENABLE_SOCKET_IPC ", " APP_DAEMON__ENABLE_WATCHDOG
+Legacy socket IPC and the daemon health watchdog. Both default to
+.BR true ;
+neither has any effect in passive mode.
+.SH AUTHENTICATION KEYS
+.TP
+.BR APP_SECRET__PRIVATE_ACCESS_KEY ", " APP_SECRET__PUBLIC_ACCESS_KEY
+.TQ
+.BR APP_SECRET__PRIVATE_REFRESH_KEY ", " APP_SECRET__PUBLIC_REFRESH_KEY
+Paths to the RSA key pairs signing access and refresh tokens. Packaged installs
+generate these into
+.I /var/lib/zm_api/keys
+on first install; they are never shipped in the package. Access and refresh
+tokens use separate pairs deliberately, so a leaked access key cannot mint
+refresh tokens.
+.SH TLS AND ACME
+.TP
+.BR APP_SERVER__TLS__ENABLED ", " APP_SERVER__TLS__CERT_PATH ", " APP_SERVER__TLS__KEY_PATH
+Static TLS. Certificates load at startup, so restart after renewal.
+.TP
+.BR APP_SERVER__ACME__ENABLED ", " APP_SERVER__ACME__DOMAINS__0 ", " APP_SERVER__ACME__CONTACT_EMAILS__0 ", " APP_SERVER__ACME__CACHE_DIR ", " APP_SERVER__ACME__PRODUCTION ", " APP_SERVER__ACME__CHALLENGE ", " APP_SERVER__ACME__HTTP_PORT
+Built-in ACME (Let's Encrypt), which keeps certificates fresh without
+restarts. List-valued settings are indexed from zero, as shown. Mutually
+exclusive with static TLS.
+.SH RATE LIMITING
+.TP
+.B APP_SERVER__MIDDLEWARE__TRUST_PROXY_HEADERS
+Whether to key rate limits on
+.B X-Forwarded-For
+/
+.BR X-Real-IP .
+Leave
+.B false
+unless a trusted reverse proxy sets them: on a directly exposed service they
+are attacker-controlled, and trusting them lets a client mint a fresh
+rate-limit bucket per request. Default
+.BR false .
+.TP
+.BR APP_SERVER__MIDDLEWARE__RATE_LIMIT_PER_SECOND ", " APP_SERVER__MIDDLEWARE__RATE_LIMIT_BURST
+Global per-IP limiter. The first value is the token replenish period in
+seconds, not a request rate. Zero disables it; it is off by default.
+.TP
+.BR APP_SERVER__MIDDLEWARE__AUTH_RATE_LIMIT_PERIOD_SECS ", " APP_SERVER__MIDDLEWARE__AUTH_RATE_LIMIT_BURST
+A tighter limiter on the authentication endpoints, on by default so credential
+brute-forcing is throttled even when the global limiter is off. Setting either
+to zero disables it.
+.SH EXAMPLES
+A dashboard on its own hostname, API behind the same reverse proxy:
+.PP
+.RS 4
+.EX
+APP_PROFILE=prod
+APP_SERVER__ALLOWED_ORIGINS=https://zm.example.com
+APP_SERVER__MIDDLEWARE__TRUST_PROXY_HEADERS=true
+.EE
+.RE
+.PP
+A remote database, overriding the
+.I zm.conf
+fallback:
+.PP
+.RS 4
+.EX
+APP_DB__HOST=10.0.0.5
+APP_DB__USERNAME=zmuser
+APP_DB__PASSWORD=secret
+.EE
+.RE
+.SH SEE ALSO
+.BR zm_api (8),
+.BR zm_api-takeover (8),
+.BR systemd.exec (5)

--- a/packaging/rpm/zm_api.spec
+++ b/packaging/rpm/zm_api.spec
@@ -60,12 +60,18 @@ cargo build --release --locked
 
 %install
 install -D -m 0755 target/release/%{appname}          %{buildroot}%{_bindir}/%{appname}
+# Built as `migrator`; installed prefixed, that name is too generic for /usr/bin.
+install -D -m 0755 target/release/migrator             %{buildroot}%{_bindir}/%{appname}-db
 install -D -m 0755 packaging/zm_api-takeover.sh        %{buildroot}%{_bindir}/%{appname}-takeover
 install -D -m 0755 packaging/setup-instance.sh         %{buildroot}%{_datadir}/%{appname}/setup-instance.sh
 install -D -m 0644 settings/base.toml                  %{buildroot}%{_sysconfdir}/%{appname}/base.toml
 install -D -m 0644 settings/prod.toml                  %{buildroot}%{_sysconfdir}/%{appname}/prod.toml
 install -D -m 0644 packaging/systemd/zm_api.env        %{buildroot}%{_sysconfdir}/%{appname}/zm_api.env
 install -D -m 0644 packaging/systemd/zm_api.service    %{buildroot}%{_unitdir}/%{appname}.service
+install -D -m 0644 packaging/man/zm_api.8              %{buildroot}%{_mandir}/man8/%{appname}.8
+install -D -m 0644 packaging/man/zm_api-takeover.8     %{buildroot}%{_mandir}/man8/%{appname}-takeover.8
+install -D -m 0644 packaging/man/zm_api-db.8           %{buildroot}%{_mandir}/man8/%{appname}-db.8
+install -D -m 0644 packaging/man/zm_api.env.5          %{buildroot}%{_mandir}/man5/zm_api.env.5
 # NOTE: static/ is not packaged — it holds dev JWT keys. Per-install keys are
 # generated into /var/lib/zm_api/keys by setup-instance.sh.
 
@@ -87,7 +93,12 @@ fi
 %files
 %license LICENSE
 %{_bindir}/%{appname}
+%{_bindir}/%{appname}-db
 %{_bindir}/%{appname}-takeover
+%{_mandir}/man8/%{appname}.8*
+%{_mandir}/man8/%{appname}-takeover.8*
+%{_mandir}/man8/%{appname}-db.8*
+%{_mandir}/man5/zm_api.env.5*
 %dir %{_datadir}/%{appname}
 %{_datadir}/%{appname}/setup-instance.sh
 %{_unitdir}/%{appname}.service

--- a/packaging/systemd/zm_api.env
+++ b/packaging/systemd/zm_api.env
@@ -5,6 +5,21 @@ APP_STATIC_DIR=/usr/share/zm_api/static
 APP_LOG_DIR=/var/log/zm_api
 RUST_LOG=info
 
+# Browser origins allowed to call this API (CORS). REQUIRED whenever a
+# dashboard (zm-dash) is served from anything other than localhost — browsers
+# block the requests otherwise, and the failure shows up only in the browser
+# console, not in this service's log.
+#
+# Comma-separated. Each entry is an exact origin ("https://zm.example.com") or
+# a host with a ":*" port wildcard ("http://localhost:*") matching any port on
+# that host. Credentials are enabled, so a bare "*" is not accepted — the CORS
+# spec forbids that pairing and browsers reject it.
+#
+# Unset defaults to localhost only. If zm-dash is served from the same origin
+# as the API (reverse proxy on one hostname), no CORS request is made and this
+# does not apply.
+# APP_SERVER__ALLOWED_ORIGINS=https://zm.example.com
+
 # Daemon controller settings
 #
 # ENABLED=false is "passive" mode: zm_api serves the REST API only and leaves
@@ -16,7 +31,11 @@ APP_DAEMON__ENABLED=false
 APP_DAEMON__SOCKET_PATH=/run/zm
 APP_DAEMON__SOCKET_NAME=zmdc.sock
 APP_DAEMON__BIN_PATH=/usr/bin
-APP_DAEMON__SCRIPT_PATH=/usr/share/zoneminder/scripts
+# Where zmdc.pl/zmfilter.pl/... live. Left unset because one packaged value
+# cannot suit every distribution — Debian/Ubuntu install the Perl scripts to
+# /usr/bin, the RPM distros to /usr/share/zoneminder/scripts. zm_api searches
+# both (and /usr/local/bin) automatically; set this only to override that.
+# APP_DAEMON__SCRIPT_PATH=/usr/share/zoneminder/scripts
 APP_DAEMON__ENABLE_SOCKET_IPC=true
 APP_DAEMON__ENABLE_WATCHDOG=true
 

--- a/packaging/systemd/zm_api.service
+++ b/packaging/systemd/zm_api.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=ZoneMinder API Service
 Documentation=https://github.com/ZoneMinder/zoneminder
+# Ordered after a local database if one is present, but deliberately not
+# dependent on it: a hard Requires=mariadb.service fails the start outright on
+# hosts using mysql.service or a remote database. Restart=on-failure covers a
+# database that is merely slow to come up.
 After=network-online.target mariadb.service mysql.service
 Wants=network-online.target
-Requires=mariadb.service
 
 [Service]
 Type=simple
@@ -11,6 +14,19 @@ Type=simple
 User=zoneminder
 Group=zoneminder
 # video: camera access, ssl-cert: TLS certificates
+#
+# Live streaming also needs read access to zmc's per-monitor stream sockets
+# ({ZM_PATH_SOCKS}/stream_*.sock), which are mode 0660 owned by ZoneMinder's
+# ZM_STREAM_SOCKET_GROUP. If that group is not "zoneminder", add it here via a
+# drop-in — NOT by editing this line, and note that naming a group that does
+# not exist makes systemd refuse to start the unit (status=216/GROUP):
+#
+#   sudo systemctl edit zm_api
+#   [Service]
+#   SupplementaryGroups=<value of ZM_STREAM_SOCKET_GROUP>
+#
+# Symptom when it is missing: streams fail and the log reports "permission
+# denied opening stream socket ...".
 SupplementaryGroups=video ssl-cert
 
 # Environment configuration

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# check-version-consistency.sh — verify the four places the version is written
+# still agree with Cargo.toml.
+#
+# Each packaging format spells a pre-release differently, so they cannot simply
+# be string-compared:
+#
+#   Cargo.toml   3.0.0-alpha.1     SemVer
+#   rpm spec     3.0.0 + 0.1.alpha1%{?dist}
+#                                  Version / Release, so the eventual stable
+#                                  (Release: 1) sorts above the pre-release
+#   PKGBUILD     3.0.0~alpha1      pacman's `~` sorts before the empty string
+#   PKGBUILD     v3.0.0-alpha.1    _pkgtag, the git tag to fetch
+#
+# Run from the repo root. Exits non-zero on any mismatch.
+#
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+fail=0
+note() { printf '  %s\n' "$1"; }
+bad() { printf 'MISMATCH: %s\n' "$1" >&2; fail=1; }
+
+cargo_version=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+[[ -n "$cargo_version" ]] || { echo "could not read version from Cargo.toml" >&2; exit 1; }
+echo "Cargo.toml version: ${cargo_version}"
+
+# Split "3.0.0-alpha.1" into base "3.0.0" and pre-release "alpha.1" (may be empty).
+base="${cargo_version%%-*}"
+pre=""
+[[ "$cargo_version" == *-* ]] && pre="${cargo_version#*-}"
+
+# --- rpm spec ---------------------------------------------------------------
+spec=packaging/rpm/zm_api.spec
+spec_version=$(grep -m1 '^Version:' "$spec" | awk '{print $2}')
+spec_release=$(grep -m1 '^Release:' "$spec" | awk '{print $2}')
+
+[[ "$spec_version" == "$base" ]] \
+  || bad "${spec} Version is '${spec_version}', expected '${base}'"
+
+if [[ -n "$pre" ]]; then
+  # e.g. alpha.1 -> alpha1, so Release should be 0.<n>.alpha1%{?dist}
+  expected_tag="${pre//./}"
+  [[ "$spec_release" == 0.*".${expected_tag}"* ]] \
+    || bad "${spec} Release is '${spec_release}'; a pre-release needs the form '0.N.${expected_tag}%{?dist}' so the stable release sorts above it"
+else
+  [[ "$spec_release" != 0.* ]] \
+    || bad "${spec} Release is '${spec_release}', but ${cargo_version} is a stable version — it should start at '1%{?dist}'"
+fi
+
+# --- PKGBUILD ---------------------------------------------------------------
+pkgbuild=packaging/arch/PKGBUILD
+pkgver=$(grep -m1 '^pkgver=' "$pkgbuild" | cut -d= -f2)
+pkgtag=$(grep -m1 '^_pkgtag=' "$pkgbuild" | cut -d= -f2)
+
+if [[ -n "$pre" ]]; then
+  expected_pkgver="${base}~${pre//./}"
+else
+  expected_pkgver="$base"
+fi
+[[ "$pkgver" == "$expected_pkgver" ]] \
+  || bad "${pkgbuild} pkgver is '${pkgver}', expected '${expected_pkgver}'"
+
+[[ "$pkgtag" == "v${cargo_version}" ]] \
+  || bad "${pkgbuild} _pkgtag is '${pkgtag}', expected 'v${cargo_version}'"
+
+# --- tag, when running on one -----------------------------------------------
+tag="${GITHUB_REF_NAME:-}"
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "$tag" ]]; then
+  [[ "$tag" == "v${cargo_version}" ]] \
+    || bad "git tag is '${tag}', expected 'v${cargo_version}'"
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "All version strings agree."
+  note "rpm      ${spec_version}-${spec_release}"
+  note "PKGBUILD ${pkgver} (tag ${pkgtag})"
+else
+  echo >&2
+  echo "Bumping a version touches: Cargo.toml, ${spec} (Version + Release + %changelog)," >&2
+  echo "and ${pkgbuild} (pkgver + _pkgtag). See docs/deployment.md." >&2
+fi
+exit $fail

--- a/settings/base.toml
+++ b/settings/base.toml
@@ -1,6 +1,20 @@
 [server]
 addr = "0.0.0.0"
 port = 8080
+# Browser origins allowed to call the API (CORS). Set this whenever a dashboard
+# (zm-dash) is served from anything other than localhost — browsers block the
+# requests otherwise, and the only symptom is in the browser console.
+#
+# Each entry is an exact origin ("https://zm.example.com") or a host with a ":*"
+# port wildcard ("http://localhost:*") matching that host on any port. A bare
+# "*" is not accepted: credentials are enabled and the CORS spec forbids that
+# pairing. Empty means localhost only.
+#
+# Same-origin deployments (zm-dash behind the same hostname via a reverse proxy)
+# make no CORS request and need nothing here.
+#
+# Override per-host with: APP_SERVER__ALLOWED_ORIGINS=https://zm.example.com
+allowed_origins = []
 
 [server.tls]
 enabled = false
@@ -112,6 +126,13 @@ mode = "go2rtc"
 max_connections = 100
 connection_timeout_seconds = 30
 stun_servers = ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"]
+# A TURN server is needed for viewers behind symmetric NAT, where STUN alone
+# cannot establish a path. Media is relayed through it, so size accordingly.
+# [streaming.webrtc.turn]
+# enabled = true
+# server = "turn:turn.example.com:3478"
+# username = "zm"
+# password = "change-me"
 
 [streaming.hls]
 enabled = true

--- a/src/configure/server.rs
+++ b/src/configure/server.rs
@@ -11,9 +11,50 @@ pub struct ServerConfig {
     pub tls: Option<ServerTlsConfig>,
     #[serde(default)]
     pub acme: Option<ServerAcmeConfig>,
+    /// Browser origins allowed to call the API (CORS). Accepts a TOML array
+    /// or, so a single environment variable can carry the whole list, one
+    /// comma-separated string: `APP_SERVER__ALLOWED_ORIGINS=https://zm.example.com`.
+    ///
+    /// Each entry is an exact origin (`https://zm.example.com`) or a host with
+    /// a `:*` port wildcard (`http://localhost:*`). Empty means "unset", which
+    /// falls back to the legacy `ALLOWED_ORIGINS` variable and then to a
+    /// localhost-only default — see `routes::resolve_allowed_origins`.
+    #[serde(default, deserialize_with = "de_string_or_seq")]
+    pub allowed_origins: Vec<String>,
     /// HTTP middleware tuning (body limits, rate limiting).
     #[serde(default)]
     pub middleware: MiddlewareConfig,
+}
+
+/// Accept either a comma-separated string or a sequence. TOML users write an
+/// array; the `APP_` environment layer can only ever deliver a string, and
+/// `APP_SERVER__ALLOWED_ORIGINS__0=` indexing is a poor fit for a setting most
+/// people set once to a single origin.
+fn de_string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrSeq {
+        String(String),
+        Seq(Vec<String>),
+    }
+
+    let split = |s: &str| -> Vec<String> {
+        s.split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(str::to_owned)
+            .collect()
+    };
+
+    Ok(match StringOrSeq::deserialize(deserializer)? {
+        StringOrSeq::String(s) => split(&s),
+        // Split sequence entries too, so a one-element array holding a
+        // comma-separated string behaves the same as the bare string.
+        StringOrSeq::Seq(v) => v.iter().flat_map(|s| split(s)).collect(),
+    })
 }
 
 /// Tuning for the cross-cutting HTTP middleware stack.
@@ -139,6 +180,43 @@ pub mod tests {
 
     use super::*;
 
+    /// The deployment path that matters: `APP_SERVER__ALLOWED_ORIGINS` arriving
+    /// through the real `config` env layer. Worth its own test because the
+    /// string-or-seq deserializer is `untagged`, which needs the backend to
+    /// support `deserialize_any` — serde_json proves nothing about the `config`
+    /// crate's own deserializer. Uses `Environment::source` rather than real
+    /// environment variables, which are process-global and race other tests.
+    #[test]
+    fn allowed_origins_round_trips_through_the_config_env_layer() {
+        let env = config::Environment::with_prefix("APP")
+            .prefix_separator("_")
+            .separator("__")
+            .source(Some(
+                [(
+                    "APP_SERVER__ALLOWED_ORIGINS".to_string(),
+                    "https://zm.example.com,https://alt.example.com".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ));
+
+        let cfg = config::Config::builder()
+            .set_default("server.addr", "0.0.0.0")
+            .unwrap()
+            .set_default("server.port", 8080)
+            .unwrap()
+            .add_source(env)
+            .build()
+            .expect("build config")
+            .get::<ServerConfig>("server")
+            .expect("deserialize ServerConfig");
+
+        assert_eq!(
+            cfg.allowed_origins,
+            vec!["https://zm.example.com", "https://alt.example.com"]
+        );
+    }
+
     #[test]
     pub fn app_config_http_addr_test() {
         let config = ServerConfig {
@@ -146,6 +224,7 @@ pub mod tests {
             port: 1024,
             tls: None,
             acme: None,
+            allowed_origins: Vec::new(),
             middleware: MiddlewareConfig::default(),
         };
         assert_eq!(config.get_http_addr(), "http://127.0.0.1:1024");
@@ -174,5 +253,42 @@ pub mod tests {
             ..Default::default()
         };
         assert!(!mw.auth_rate_limiting_enabled());
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct OriginsHolder {
+        #[serde(default, deserialize_with = "de_string_or_seq")]
+        allowed_origins: Vec<String>,
+    }
+
+    fn parse_origins(json: &str) -> Vec<String> {
+        serde_json::from_str::<OriginsHolder>(json)
+            .expect("parse")
+            .allowed_origins
+    }
+
+    #[test]
+    fn allowed_origins_accepts_a_sequence() {
+        // The shape a TOML array in base.toml deserializes to.
+        assert_eq!(
+            parse_origins(r#"{"allowed_origins": ["https://a.example", "http://localhost:*"]}"#),
+            vec!["https://a.example", "http://localhost:*"]
+        );
+    }
+
+    #[test]
+    fn allowed_origins_accepts_a_comma_separated_string() {
+        // The only shape the APP_SERVER__ALLOWED_ORIGINS env layer can produce.
+        assert_eq!(
+            parse_origins(r#"{"allowed_origins": "https://a.example, http://localhost:*"}"#),
+            vec!["https://a.example", "http://localhost:*"]
+        );
+    }
+
+    #[test]
+    fn allowed_origins_defaults_to_empty_and_drops_blanks() {
+        assert!(parse_origins("{}").is_empty());
+        assert!(parse_origins(r#"{"allowed_origins": "  ,, "}"#).is_empty());
+        assert!(parse_origins(r#"{"allowed_origins": []}"#).is_empty());
     }
 }

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for the daemon controller.
 
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Configuration for the daemon controller service.
@@ -29,7 +29,9 @@ pub struct DaemonConfig {
     #[serde(default = "default_bin_path")]
     pub bin_path: PathBuf,
 
-    /// Path to ZM scripts (default: /usr/share/zoneminder/scripts)
+    /// Path to ZM scripts (default: /usr/bin). Only a hint — see
+    /// [`DaemonConfig::resolve_daemon_path`], which searches the standard
+    /// per-distribution locations when the configured one has no match.
     #[serde(default = "default_script_path")]
     pub script_path: PathBuf,
 
@@ -128,14 +130,48 @@ impl DaemonConfig {
     }
 
     /// Resolve a daemon command to its full path.
+    ///
+    /// The configured directory is tried first, then the standard locations —
+    /// distributions disagree about where ZoneMinder's Perl scripts land
+    /// (`/usr/bin` on Debian/Ubuntu, `/usr/share/zoneminder/scripts` on the RPM
+    /// distros), and a single packaged default cannot be right for everyone.
+    /// Falls back to the configured path when nothing exists, so a genuinely
+    /// missing daemon still reports the path the operator configured.
     pub fn resolve_daemon_path(&self, command: &str) -> PathBuf {
-        if command.ends_with(".pl") {
-            self.script_path.join(command)
+        let configured = if command.ends_with(".pl") {
+            &self.script_path
         } else {
-            self.bin_path.join(command)
+            &self.bin_path
+        };
+        let fallbacks = if command.ends_with(".pl") {
+            SCRIPT_PATH_FALLBACKS
+        } else {
+            BIN_PATH_FALLBACKS
+        };
+
+        let preferred = configured.join(command);
+        if preferred.exists() {
+            return preferred;
         }
+        for dir in fallbacks {
+            let candidate = Path::new(dir).join(command);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+        preferred
     }
 }
+
+/// Where ZoneMinder's Perl scripts live, by distribution.
+const SCRIPT_PATH_FALLBACKS: &[&str] = &[
+    "/usr/bin",                      // Debian / Ubuntu
+    "/usr/share/zoneminder/scripts", // Fedora / openSUSE / RHEL
+    "/usr/local/bin",                // source installs
+];
+
+/// Where ZoneMinder's compiled binaries (zmc, zma) live.
+const BIN_PATH_FALLBACKS: &[&str] = &["/usr/bin", "/usr/local/bin"];
 
 fn default_enabled() -> bool {
     // Passive by default: never seize daemon control from a running ZoneMinder
@@ -244,5 +280,52 @@ mod tests {
         assert_eq!(config.stats_update_interval(), Duration::from_secs(60));
         assert_eq!(config.watch_check_interval(), Duration::from_secs(10));
         assert_eq!(config.watch_max_delay(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn resolve_prefers_the_configured_directory_when_it_has_the_script() {
+        // Per-process dir: a fixed name would collide between concurrent runs.
+        let dir =
+            std::env::temp_dir().join(format!("zmapi-resolve-configured-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("zmdc.pl"), b"").unwrap();
+
+        let cfg = DaemonConfig {
+            script_path: dir.clone(),
+            ..DaemonConfig::default()
+        };
+        assert_eq!(cfg.resolve_daemon_path("zmdc.pl"), dir.join("zmdc.pl"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_falls_back_to_the_configured_path_when_nothing_exists() {
+        // A genuinely missing daemon must still report the configured location,
+        // not a fallback the operator never chose.
+        let cfg = DaemonConfig {
+            script_path: PathBuf::from("/nonexistent/zm/scripts"),
+            ..DaemonConfig::default()
+        };
+        assert_eq!(
+            cfg.resolve_daemon_path("definitely-not-a-real-daemon.pl"),
+            PathBuf::from("/nonexistent/zm/scripts/definitely-not-a-real-daemon.pl")
+        );
+    }
+
+    #[test]
+    fn scripts_and_binaries_use_their_own_search_paths() {
+        // `.pl` resolves against script_path, everything else against bin_path.
+        let cfg = DaemonConfig {
+            script_path: PathBuf::from("/nonexistent/scripts"),
+            bin_path: PathBuf::from("/nonexistent/bin"),
+            ..DaemonConfig::default()
+        };
+        assert!(cfg
+            .resolve_daemon_path("zmnosuch.pl")
+            .starts_with("/nonexistent/scripts"));
+        assert!(cfg
+            .resolve_daemon_path("zmnosuch")
+            .starts_with("/nonexistent/bin"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,81 @@ use zm_api::error::AppResult;
 use zm_api::server::AppServer;
 use zm_api::{configure, util};
 
+const USAGE: &str = "\
+zm_api — REST API server for a ZoneMinder installation
+
+Usage: zm_api [OPTIONS]
+
+Options:
+  -h, --help       Print this help and exit
+  -V, --version    Print the version and exit
+      --openapi    Write the OpenAPI 3 spec to stdout and exit
+
+The server takes no other arguments; it is configured entirely from files and
+environment variables, loaded in this order (last wins):
+
+  1. ZoneMinder's /etc/zm/zm.conf (database settings only)
+  2. <config dir>/base.toml
+  3. <config dir>/{APP_PROFILE}.toml
+  4. APP_* environment variables
+
+The config dir is $APP_CONFIG_DIR, else ./settings. Nested keys use a double
+underscore: APP_DB__HOST=10.0.0.5 sets db.host.
+
+Key variables:
+  APP_PROFILE                  dev | test | test-db | prod   (default: dev)
+  APP_CONFIG_DIR               config directory              (packaged: /etc/zm_api)
+  APP_STATIC_DIR               static assets                 (packaged: /usr/share/zm_api/static)
+  APP_SERVER__ALLOWED_ORIGINS  CORS origins for a browser dashboard
+  APP_DAEMON__ENABLED          false = passive (REST only), true = supervise ZM daemons
+  RUST_LOG                     log filter                    (e.g. info, zm_api=debug)
+
+Docs: https://github.com/SteveGilvarry/zm-api
+";
+
+/// Handle `--help`/`--version` before anything else initialises. Returns true
+/// when the process should exit — deliberately ahead of config loading and
+/// tracing setup, so both work on a host whose config is broken.
+fn handle_cli_args() -> bool {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        None => false,
+        Some("-h" | "--help") => {
+            print!("{USAGE}");
+            true
+        }
+        Some("-V" | "--version") => {
+            println!("zm_api {}", env!("CARGO_PKG_VERSION"));
+            true
+        }
+        // Lets the spec be diffed between releases, attached to a release, and
+        // fed to a client generator without standing a server up.
+        Some("--openapi") => {
+            use utoipa::OpenApi;
+            match zm_api::handlers::openapi::ApiDoc::openapi().to_pretty_json() {
+                Ok(json) => println!("{json}"),
+                Err(e) => {
+                    eprintln!("zm_api: could not serialise the OpenAPI spec: {e}");
+                    std::process::exit(1);
+                }
+            }
+            true
+        }
+        Some(other) => {
+            eprintln!("zm_api: unrecognised argument '{other}'\n");
+            eprint!("{USAGE}");
+            std::process::exit(2);
+        }
+    }
+}
+
 #[tokio::main]
 #[allow(clippy::result_large_err)]
 async fn main() -> AppResult<()> {
+    if handle_cli_args() {
+        return Ok(());
+    }
+
     // Install the rustls CryptoProvider before any TLS/DTLS usage.
     // Required by rustls 0.23+ (used by webrtc-rs DTLS, axum-server TLS, sqlx).
     zm_api::install_crypto_provider();

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -115,27 +115,99 @@ impl OriginRule {
     }
 }
 
-/// Build the CORS layer from the `ALLOWED_ORIGINS` environment variable.
+/// Origins allowed when nothing is configured: any localhost / 127.0.0.1 port,
+/// so new frontend dev ports don't need registering one by one. Deliberately
+/// useless in production — a packaged install serving a dashboard from a real
+/// hostname must set `server.allowed_origins`.
+const DEFAULT_ALLOWED_ORIGINS: &[&str] = &["http://localhost:*", "http://127.0.0.1:*"];
+
+/// Legacy, un-prefixed environment variable. Superseded by
+/// `server.allowed_origins` (`APP_SERVER__ALLOWED_ORIGINS`) but still honoured
+/// so existing deployments keep working across the upgrade.
+const LEGACY_ORIGINS_ENV: &str = "ALLOWED_ORIGINS";
+
+/// Where the effective origin list came from, for the startup log line.
+#[derive(Debug, PartialEq, Eq)]
+enum OriginSource {
+    Config,
+    LegacyEnv,
+    Default,
+}
+
+/// Resolve the effective allowed-origin list: configured value first, then the
+/// legacy environment variable, then the localhost-only default.
 ///
-/// `ALLOWED_ORIGINS` is a comma-separated list. Each entry is either an exact
-/// origin (`https://app.example.com`) or a host with a `:*` port wildcard
-/// (`http://localhost:*`) that matches that host on any port. The default
-/// (dev) allows any localhost / 127.0.0.1 port so new frontend dev ports don't
-/// need to be registered one by one.
+/// Split out from [`build_cors_layer`] so the precedence is testable without
+/// mutating process environment.
+fn resolve_allowed_origins(
+    configured: &[String],
+    legacy: Option<String>,
+) -> (Vec<String>, OriginSource) {
+    if !configured.is_empty() {
+        return (configured.to_vec(), OriginSource::Config);
+    }
+    if let Some(raw) = legacy {
+        let parsed: Vec<String> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+        if !parsed.is_empty() {
+            return (parsed, OriginSource::LegacyEnv);
+        }
+    }
+    (
+        DEFAULT_ALLOWED_ORIGINS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        OriginSource::Default,
+    )
+}
+
+/// Build the CORS layer from `server.allowed_origins`.
+///
+/// Each entry is either an exact origin (`https://app.example.com`) or a host
+/// with a `:*` port wildcard (`http://localhost:*`) that matches that host on
+/// any port.
 ///
 /// Note: the layer sets `Access-Control-Allow-Credentials: true`, and the CORS
 /// spec forbids pairing credentials with a literal `*` origin (browsers reject
 /// it). So "all origins" is intentionally not offered; the `:*` rule reflects
 /// the specific matching origin back instead, which is credentials-safe and,
 /// for `localhost`, does not expose the API to other hosts. In production set
-/// `ALLOWED_ORIGINS` to the exact deployed front-end origin(s).
+/// `server.allowed_origins` to the exact deployed front-end origin(s).
 fn build_cors_layer() -> CorsLayer {
-    let frontend_urls = std::env::var("ALLOWED_ORIGINS")
-        .unwrap_or_else(|_| "http://localhost:*,http://127.0.0.1:*".to_string());
+    let (origins, source) = resolve_allowed_origins(
+        &crate::constant::CONFIG.server.allowed_origins,
+        std::env::var(LEGACY_ORIGINS_ENV).ok(),
+    );
 
+    match source {
+        OriginSource::Config => {
+            tracing::info!("CORS allowed origins (server.allowed_origins): {origins:?}");
+        }
+        OriginSource::LegacyEnv => {
+            tracing::warn!(
+                "CORS allowed origins came from the deprecated {LEGACY_ORIGINS_ENV} \
+                 environment variable: {origins:?}. Set server.allowed_origins \
+                 (APP_SERVER__ALLOWED_ORIGINS) instead."
+            );
+        }
+        OriginSource::Default => {
+            // Say this loudly: a dashboard on any other origin is CORS-blocked,
+            // and the browser-side symptom gives no hint of the cause.
+            tracing::warn!(
+                "CORS allowed origins not configured, defaulting to {origins:?}. \
+                 Browsers will block a dashboard served from any other origin — \
+                 set server.allowed_origins (APP_SERVER__ALLOWED_ORIGINS) to it."
+            );
+        }
+    }
+
+    let frontend_urls = origins.join(",");
     let rules = parse_origin_rules(&frontend_urls);
-
-    tracing::info!("Configuring CORS with allowed origins: {:?}", frontend_urls);
 
     let allow_origin = AllowOrigin::predicate(move |origin: &HeaderValue, _req| {
         rules.iter().any(|r| r.matches(origin))
@@ -164,7 +236,7 @@ fn build_cors_layer() -> CorsLayer {
         .allow_credentials(true)
 }
 
-/// Parse `ALLOWED_ORIGINS` into a set of [`OriginRule`]s. Entries ending in
+/// Parse an origin list into a set of [`OriginRule`]s. Entries ending in
 /// `:*` become any-port host rules; the rest are exact origins. Entries that
 /// are neither parseable as a header value nor a `:*` rule are skipped.
 fn parse_origin_rules(raw: &str) -> Vec<OriginRule> {
@@ -592,5 +664,33 @@ mod tests {
         let rules = parse_origin_rules(" , ,http://localhost:*, ");
         assert_eq!(rules.len(), 1);
         assert!(allows(&rules, "http://localhost:9999"));
+    }
+
+    #[test]
+    fn configured_origins_win_over_the_legacy_env_var() {
+        let configured = vec!["https://zm.example.com".to_string()];
+        let (origins, source) =
+            resolve_allowed_origins(&configured, Some("https://stale.example".into()));
+        assert_eq!(origins, configured);
+        assert_eq!(source, OriginSource::Config);
+    }
+
+    #[test]
+    fn legacy_env_var_is_still_honoured_when_nothing_is_configured() {
+        // Existing deployments set only the bare ALLOWED_ORIGINS; upgrading
+        // must not silently start CORS-blocking their dashboard.
+        let (origins, source) =
+            resolve_allowed_origins(&[], Some(" https://a.example, https://b.example ".into()));
+        assert_eq!(origins, vec!["https://a.example", "https://b.example"]);
+        assert_eq!(source, OriginSource::LegacyEnv);
+    }
+
+    #[test]
+    fn falls_back_to_localhost_when_unset_or_blank() {
+        for legacy in [None, Some(String::new()), Some(" , ".to_string())] {
+            let (origins, source) = resolve_allowed_origins(&[], legacy);
+            assert_eq!(origins, DEFAULT_ALLOWED_ORIGINS);
+            assert_eq!(source, OriginSource::Default);
+        }
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -72,8 +72,12 @@ impl AppState {
             SearchService::new(http.clone(), db.clone(), config.search.clone()).await,
         ));
 
-        // Initialize native WebRTC engine (Phase 2)
-        let native_webrtc_engine = match WebRtcEngine::new(Default::default()) {
+        // Initialize native WebRTC engine (Phase 2). Pass the configured
+        // `[streaming.webrtc]` block, not the defaults: the engine turns
+        // `stun_servers`/`turn` into its ICE server list, so defaulting here
+        // silently discarded any configured TURN server and left clients behind
+        // symmetric NAT unable to connect.
+        let native_webrtc_engine = match WebRtcEngine::new(config.streaming.webrtc.clone()) {
             Ok(engine) => {
                 tracing::info!("Native WebRTC engine initialized successfully");
                 Some(Arc::new(engine))

--- a/src/streaming/source/stream_socket.rs
+++ b/src/streaming/source/stream_socket.rs
@@ -51,6 +51,15 @@ pub enum SourceError {
     #[error("stream socket not found: {path}")]
     NotFound { path: PathBuf },
 
+    /// The socket exists but this process may not open it. zmc creates it mode
+    /// 0660 owned by `ZM_STREAM_SOCKET_GROUP`, so the bare OS message ("permission
+    /// denied") names nothing the operator can act on.
+    #[error(
+        "permission denied opening stream socket {path}: the zm_api service user must be a \
+         member of ZoneMinder's ZM_STREAM_SOCKET_GROUP (the socket is mode 0660)"
+    )]
+    PermissionDenied { path: PathBuf },
+
     #[error("stream socket I/O error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -83,6 +92,18 @@ pub enum SocketEvent {
     /// media; routed to DB ingest rather than the media sinks. EVENTs use their
     /// own per-monitor sequence counter, independent of the media streams.
     MonitorEvent(MonitorEvent),
+}
+
+/// Turn a connect failure into the most actionable variant we can. EACCES is
+/// the one worth naming: it means group membership, not a missing camera, and
+/// it is otherwise indistinguishable from any other I/O error in the log.
+fn classify_connect_error(e: std::io::Error, path: &Path) -> SourceError {
+    match e.kind() {
+        std::io::ErrorKind::PermissionDenied => SourceError::PermissionDenied {
+            path: path.to_path_buf(),
+        },
+        _ => SourceError::Io(e),
+    }
 }
 
 /// The documented-convention socket path for a monitor:
@@ -193,7 +214,9 @@ impl StreamSocketReader {
             self.path.display()
         );
 
-        let stream = UnixStream::connect(&self.path).await?;
+        let stream = UnixStream::connect(&self.path)
+            .await
+            .map_err(|e| classify_connect_error(e, &self.path))?;
         let (read, write) = stream.into_split();
         self.read = Some(read);
         self.write = Some(write);
@@ -1111,5 +1134,29 @@ mod tests {
 
         server.abort();
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn eacces_on_connect_names_the_stream_socket_group() {
+        // zmc creates the socket 0660; if zm_api's user isn't in
+        // ZM_STREAM_SOCKET_GROUP every stream fails with a bare "permission
+        // denied" that points at nothing. The error must name the fix.
+        let err = classify_connect_error(
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+            Path::new("/run/zm/stream_1.sock"),
+        );
+        assert!(matches!(err, SourceError::PermissionDenied { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("ZM_STREAM_SOCKET_GROUP"), "got: {msg}");
+        assert!(msg.contains("/run/zm/stream_1.sock"), "got: {msg}");
+    }
+
+    #[test]
+    fn other_connect_errors_stay_generic_io() {
+        let err = classify_connect_error(
+            std::io::Error::from(std::io::ErrorKind::ConnectionRefused),
+            Path::new("/run/zm/stream_1.sock"),
+        );
+        assert!(matches!(err, SourceError::Io(_)));
     }
 }

--- a/src/streaming/webrtc/engine.rs
+++ b/src/streaming/webrtc/engine.rs
@@ -545,6 +545,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn engine_keeps_the_ice_servers_it_was_configured_with() {
+        // Regression: AppState built the engine with `Default::default()`, so a
+        // configured TURN server was parsed and then thrown away — WebRTC failed
+        // for clients behind symmetric NAT with nothing in the log to say why.
+        use crate::configure::streaming::TurnConfig;
+
+        let engine = WebRtcEngine::new(WebRtcConfig {
+            stun_servers: vec!["stun:stun.example.com:3478".to_string()],
+            turn: Some(TurnConfig {
+                enabled: true,
+                server: "turn:turn.example.com:3478".to_string(),
+                username: "user".to_string(),
+                password: "pass".to_string(),
+            }),
+            ..WebRtcConfig::default()
+        })
+        .expect("engine");
+
+        let urls: Vec<&str> = engine
+            .ice_servers
+            .iter()
+            .flat_map(|s| s.urls.iter().map(String::as_str))
+            .collect();
+        assert!(urls.contains(&"stun:stun.example.com:3478"), "got {urls:?}");
+        assert!(urls.contains(&"turn:turn.example.com:3478"), "got {urls:?}");
+    }
+
+    #[tokio::test]
     async fn offer_advertises_actpass_dtls_role() {
         // Documents the webrtc-rs invariant that drives the ~1.1s DTLS gap: as
         // the offerer we always send `setup:actpass`, so the role resolves via


### PR DESCRIPTION
Closes #50. Addresses most of #51.

## The four shipped-default defects (#50)

Each produced a failure the user could not easily diagnose.

**CORS was undiscoverable.** The allowed-origin list came from a bare, un-prefixed `ALLOWED_ORIGINS` that appeared in no config file, no env file, and no doc — defaulting to localhost. A dashboard on any other origin was silently blocked, reported only in the browser console, with no string in the repo to grep for.

Now `server.allowed_origins` / `APP_SERVER__ALLOWED_ORIGINS`, accepting either a TOML array or a comma-separated string (the only shape the env layer can produce). The old variable is still honoured with a deprecation warning so existing deployments survive the upgrade, and the effective list *and its source* are logged at startup — including a loud warning when it fell back to the default.

**`APP_DAEMON__SCRIPT_PATH` was wrong for Debian/Ubuntu.** One env file serves deb, rpm and Arch, so no single value can be right. `resolve_daemon_path` now searches the standard per-distribution locations (`/usr/bin`, `/usr/share/zoneminder/scripts`, `/usr/local/bin`), with the setting as an override and the configured path still winning when it has a match.

**`Requires=mariadb.service` failed the unit** on mysql.service or a remote database. Dropped — `After=` still orders it, `Restart=on-failure` covers a slow database.

**Stream-socket permission errors named nothing actionable.** A dedicated error now names `ZM_STREAM_SOCKET_GROUP`. The group deliberately isn't hardcoded in the unit: naming a group that doesn't exist makes systemd refuse to start (`216/GROUP`), which would be worse than the bug. The unit documents the `systemctl edit` drop-in instead.

## A real bug found while writing the architecture doc

`AppState` built the WebRTC engine with `Default::default()` instead of the loaded `[streaming.webrtc]` config. The engine parses `stun_servers`/`turn` into its ICE server list correctly — the config just never reached it. **A configured TURN server had no effect**, so viewers behind symmetric NAT could not connect, with nothing in the log to explain it. Fixed, with a regression test asserting the constructed engine retains its ICE servers.

## Release readiness (#51)

- **Man pages** — `zm_api(8)`, `zm_api.env(5)`, `zm_api-takeover(8)`, `zm_api-db(8)`, installed by all three packages. The takeover page carries the prerequisites, a verification procedure, and rollback guidance that `docs/deployment.md` only gestured at.
- **`--help` / `--version` / `--openapi`** on the server binary, handled before config loads so they answer on a host whose config is broken. `--openapi` writes the spec (163 paths) to stdout.
- **`zm_api-db` now ships.** It was built but packaged nowhere, so there was no upgrade path for an existing ZoneMinder database — and startup migration failure is only a `warn!`, so the symptom was a healthy-looking service with features silently missing. Installed prefixed because `migrator` is far too generic for `/usr/bin`; the cargo bin name is unchanged so the parity scripts keep working.
- **`docs/architecture.md`** — the three-component story, previously unwritten (zm-dash appeared once in the whole repo, in passing). Includes the finding that **zm_api serves no static files and has no SPA fallback**, so a dashboard is always served by something else; both deployment shapes are documented with a working nginx config.
- **`CHANGELOG.md`**, with release notes extracted from it instead of a raw commit list, plus `SHA256SUMS` over every artifact.
- **OpenAPI exported in CI** and attached to each release.
- **`scripts/check-version-consistency.sh`** gates the release workflow — the four version strings are hand-synced and each format spells a pre-release differently, so this fails a half-finished bump before three package builds run. Verified it catches drift, not just that it passes.
- **`packaging/install.sh` rewritten** to match the package layout. It had installed the unit to `/etc/systemd/system` (packages use `/lib/...`, so both would be active) and never generated JWT keys, leaving a freshly "installed" service unable to sign a token.
- `docs/tls.md` claimed the unit uses `DynamicUser`; it runs as `User=zoneminder`. README test count and coverage refreshed against a measured run (1,100+ tests, ~62%). Removed the dead `[package.metadata.rpm]` block — nothing invoked cargo-rpm and it duplicated the spec.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` all clean — **860 passed, 0 failed** (272 DB-gated tests ignored without a database). New tests cover origin-resolution precedence, the string-or-array deserializer through the real `config` env layer (untagged enums need `deserialize_any`, which serde_json alone doesn't prove), daemon path resolution, the EACCES message, and the WebRTC ICE regression. Man pages checked with `man`; the changelog extraction and version check exercised by hand.

## Not addressed from #51

Distro build matrix (bookworm/22.04, RHEL/Rocky/Alma rpm, arm64 for rpm+Arch), package repositories (COPR/OBS/AUR/apt), artifact signing, the mdBook migration, and the dual-license artifact — that last one is a business decision, not a code change.