### PR TITLE
Validate request DTOs that were only pretending to be validated (#52, #38)

### DIFF
--- a/src/configure/env.rs
+++ b/src/configure/env.rs
@@ -19,3 +19,44 @@ pub fn get_profile() -> Result<Profile, config::ConfigError> {
         .map(|env| Profile::from_str(&env).map_err(|e| ConfigError::Message(e.to_string())))
         .unwrap_or_else(|_e| Ok(Profile::Dev))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Resolve one variable through the real source, using `Environment::source`
+    /// rather than the process environment (which is global and races other
+    /// tests).
+    fn resolve(var: &str, key: &str) -> Option<String> {
+        config::Config::builder()
+            .add_source(
+                get_env_source("APP").source(Some(
+                    [(var.to_string(), "10.0.0.5".to_string())]
+                        .into_iter()
+                        .collect(),
+                )),
+            )
+            .build()
+            .expect("build config")
+            .get::<String>(key)
+            .ok()
+    }
+
+    #[test]
+    fn documented_single_underscore_prefix_is_honoured() {
+        // GH #38: the prefix separator was `__`, so the documented
+        // `APP_DB__HOST` was silently ignored — the server connected with the
+        // default credentials and gave no indication the override was dropped.
+        assert_eq!(
+            resolve("APP_DB__HOST", "db.host").as_deref(),
+            Some("10.0.0.5")
+        );
+    }
+
+    #[test]
+    fn double_underscore_prefix_no_longer_matches() {
+        // The accidental form must not keep working, or the two spellings
+        // silently disagree about which wins.
+        assert_eq!(resolve("APP__DB__HOST", "db.host"), None);
+    }
+}

--- a/src/dto/request/reports.rs
+++ b/src/dto/request/reports.rs
@@ -1,32 +1,126 @@
+use garde::Validate;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+/// `Reports.Name` is `varchar(30)` in ZoneMinder's schema. Validating against
+/// the column width turns an over-long name into a 400 naming the field,
+/// instead of the 500 the truncation error used to surface as (GH #52).
+///
+/// Counted in `chars`, not garde's default of bytes: `varchar(30)` is 30
+/// *characters*, so byte-counting would spuriously reject a legitimate
+/// 30-character name containing any multi-byte character.
+const NAME_MAX: usize = 30;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Validate)]
 pub struct CreateReportRequest {
-    #[schema(example = "Weekly Security Report")]
+    #[garde(inner(length(chars, max = NAME_MAX)))]
+    #[schema(example = "Weekly Security Report", max_length = 30)]
     pub name: Option<String>,
+    #[garde(skip)]
     #[schema(example = 1)]
     pub filter_id: Option<u32>,
+    #[garde(skip)]
     #[schema(value_type = String, example = "2025-01-01T00:00:00Z")]
     pub start_date_time: Option<String>,
+    #[garde(skip)]
     #[schema(value_type = String, example = "2025-01-08T00:00:00Z")]
     pub end_date_time: Option<String>,
     /// Report interval in seconds (e.g. 604800 = 7 days).
+    #[garde(skip)]
     #[schema(example = 604800)]
     pub interval: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, Validate)]
 pub struct UpdateReportRequest {
-    #[schema(example = "Weekly Security Report")]
+    #[garde(inner(length(chars, max = NAME_MAX)))]
+    #[schema(example = "Weekly Security Report", max_length = 30)]
     pub name: Option<String>,
+    #[garde(skip)]
     #[schema(example = 1)]
     pub filter_id: Option<u32>,
+    #[garde(skip)]
     #[schema(value_type = String, example = "2025-01-01T00:00:00Z")]
     pub start_date_time: Option<String>,
+    #[garde(skip)]
     #[schema(value_type = String, example = "2025-01-08T00:00:00Z")]
     pub end_date_time: Option<String>,
     /// Report interval in seconds (e.g. 604800 = 7 days).
+    #[garde(skip)]
     #[schema(example = 604800)]
     pub interval: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_with_name(name: &str) -> CreateReportRequest {
+        CreateReportRequest {
+            name: Some(name.to_string()),
+            filter_id: None,
+            start_date_time: None,
+            end_date_time: None,
+            interval: None,
+        }
+    }
+
+    #[test]
+    fn name_at_the_column_width_is_accepted() {
+        // 30 characters is exactly what the column holds; it must not be
+        // rejected. The reported boundary was 30 ok / 31 a 500.
+        let req = create_with_name(&"a".repeat(NAME_MAX));
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn name_over_the_column_width_is_a_validation_error_naming_the_field() {
+        let req = create_with_name(&"a".repeat(NAME_MAX + 1));
+        let err = req.validate().expect_err("31 chars must not validate");
+        assert!(
+            err.to_string().contains("name"),
+            "the error must name the offending field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn the_bound_counts_characters_not_bytes() {
+        // garde's default length mode is bytes, but varchar(30) is 30
+        // characters. 30 multi-byte characters (90 bytes here) fit the column
+        // and must be accepted; byte-counting would reject them.
+        let multibyte = "é".repeat(NAME_MAX);
+        assert_eq!(multibyte.chars().count(), NAME_MAX);
+        assert!(multibyte.len() > NAME_MAX, "must actually be multi-byte");
+
+        let req = create_with_name(&multibyte);
+        assert!(
+            req.validate().is_ok(),
+            "30 multi-byte characters fit varchar(30) and must validate"
+        );
+    }
+
+    #[test]
+    fn an_absent_name_is_still_allowed() {
+        // Reports.Name is nullable; validation must not make it required.
+        let req = CreateReportRequest {
+            name: None,
+            filter_id: None,
+            start_date_time: None,
+            end_date_time: None,
+            interval: None,
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn update_enforces_the_same_bound() {
+        let too_long = UpdateReportRequest {
+            name: Some("a".repeat(NAME_MAX + 1)),
+            filter_id: None,
+            start_date_time: None,
+            end_date_time: None,
+            interval: None,
+        };
+        assert!(too_long.validate().is_err());
+    }
 }

--- a/src/handlers/ai.rs
+++ b/src/handlers/ai.rs
@@ -197,6 +197,7 @@ pub async fn list_classes(
     Query(params): Query<PaginationParams>,
     State(state): State<AppState>,
 ) -> AppResult<Json<PaginatedAiObjectClassesResponse>> {
+    filter.validate().map_err(AppError::InvalidInputError)?;
     let result = service::ai::list_classes(&state, &params, filter.dataset_id).await?;
     Ok(Json(PaginatedAiObjectClassesResponse::from(result)))
 }

--- a/src/handlers/configs.rs
+++ b/src/handlers/configs.rs
@@ -2,12 +2,13 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
+use garde::Validate;
 use tracing::info;
 
 use crate::dto::request::config::ConfigQueryParams;
 use crate::dto::response::config::{CategoryCountResponse, PaginatedConfigsResponse};
 use crate::dto::{request::config::UpdateConfigRequest, response::config::ConfigResponse};
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::server::state::AppState;
 use crate::service;
 
@@ -38,6 +39,7 @@ pub async fn list_configs(
     Query(params): Query<ConfigQueryParams>,
 ) -> AppResult<Json<PaginatedConfigsResponse>> {
     info!("Listing config entries with pagination");
+    params.validate().map_err(AppError::InvalidInputError)?;
     let result = service::config::list_filtered(&state, &params).await?;
     Ok(Json(PaginatedConfigsResponse::from(result)))
 }

--- a/src/handlers/logs.rs
+++ b/src/handlers/logs.rs
@@ -1,11 +1,12 @@
 use crate::dto::request::logs::LogQueryParams;
 use crate::dto::response::logs::{LogResponse, PaginatedLogsResponse};
-use crate::error::{AppResponseError, AppResult};
+use crate::error::{AppError, AppResponseError, AppResult};
 use crate::server::state::AppState;
 use axum::{
     extract::{Path, Query, State},
     Json,
 };
+use garde::Validate;
 use tracing::{info, instrument};
 
 /// List log entries with pagination and filtering.
@@ -44,6 +45,9 @@ pub async fn list_logs(
     Query(params): Query<LogQueryParams>,
 ) -> AppResult<Json<PaginatedLogsResponse>> {
     info!("Listing logs with params: {:?}", params);
+    // Without this the declared bounds are inert: page_size=0 reaches
+    // `div_ceil` and SeaORM's `paginate`, both of which panic on zero.
+    params.validate().map_err(AppError::InvalidInputError)?;
 
     let result = crate::service::logs::list(&state, &params).await?;
     Ok(Json(result))
@@ -79,6 +83,7 @@ pub async fn clear_logs(
     State(state): State<AppState>,
     Query(params): Query<LogQueryParams>,
 ) -> AppResult<Json<crate::dto::response::MessageResponse>> {
+    params.validate().map_err(AppError::InvalidInputError)?;
     let deleted = crate::service::logs::delete(&state, &params).await?;
     info!("Cleared {deleted} log rows");
     Ok(Json(crate::dto::response::MessageResponse::new(&format!(

--- a/src/handlers/monitor.rs
+++ b/src/handlers/monitor.rs
@@ -221,6 +221,7 @@ pub async fn update_state(
     Json(req): Json<UpdateStateRequest>,
 ) -> AppResult<Json<MonitorResponse>> {
     info!("Updating state of monitor with ID: {id} and request: {req:?}.");
+    req.validate().map_err(AppError::InvalidInputError)?;
     match service::monitor::update_state(&state, id, req, &scope).await {
         Ok(monitor) => Ok(Json(monitor)),
         Err(e) => {
@@ -256,6 +257,10 @@ pub async fn alarm_control(
     Json(req): Json<AlarmControlRequest>,
 ) -> AppResult<Json<MonitorResponse>> {
     info!("Controlling alarm of monitor with ID: {id} and request: {req:?}.");
+    // The cause/text bounds mirror the shared-memory buffers; enforcing them
+    // here turns an over-long value into a 400 naming the field rather than an
+    // error raised deep in the shm write.
+    req.validate().map_err(AppError::InvalidInputError)?;
     match service::monitor::control_alarm(&state, id, req, &scope).await {
         Ok(monitor) => Ok(Json(monitor)),
         Err(e) => {

--- a/src/handlers/reports.rs
+++ b/src/handlers/reports.rs
@@ -2,12 +2,13 @@ use crate::dto::request::reports::{CreateReportRequest, UpdateReportRequest};
 use crate::dto::response::reports::PaginatedReportsResponse;
 use crate::dto::response::ReportResponse;
 use crate::dto::PaginationParams;
-use crate::error::AppResult;
+use crate::error::{AppError, AppResult};
 use crate::server::state::AppState;
 use axum::{
     extract::{Path, Query, State},
     Json,
 };
+use garde::Validate;
 
 /// List all reports with pagination.
 ///
@@ -53,7 +54,10 @@ pub async fn get_report(
     post,
     path = "/api/v3/reports",
     request_body = CreateReportRequest,
-    responses((status = 201, description = "Created report", body = ReportResponse)),
+    responses(
+        (status = 201, description = "Created report", body = ReportResponse),
+        (status = 400, description = "Invalid input", body = crate::error::AppResponseError)
+    ),
     tag = "Reports",
     security(("jwt" = []))
 )]
@@ -61,6 +65,7 @@ pub async fn create_report(
     State(state): State<AppState>,
     Json(req): Json<CreateReportRequest>,
 ) -> AppResult<(axum::http::StatusCode, Json<ReportResponse>)> {
+    req.validate().map_err(AppError::InvalidInputError)?;
     let item = crate::service::reports::create(&state, req).await?;
     Ok((axum::http::StatusCode::CREATED, Json(item)))
 }
@@ -71,7 +76,10 @@ pub async fn create_report(
     path = "/api/v3/reports/{id}",
     params(("id" = u32, Path, description = "Report ID")),
     request_body = UpdateReportRequest,
-    responses((status = 200, description = "Updated report", body = ReportResponse)),
+    responses(
+        (status = 200, description = "Updated report", body = ReportResponse),
+        (status = 400, description = "Invalid input", body = crate::error::AppResponseError)
+    ),
     tag = "Reports",
     security(("jwt" = []))
 )]
@@ -80,6 +88,7 @@ pub async fn update_report(
     State(state): State<AppState>,
     Json(req): Json<UpdateReportRequest>,
 ) -> AppResult<Json<ReportResponse>> {
+    req.validate().map_err(AppError::InvalidInputError)?;
     let item = crate::service::reports::update(&state, id, req).await?;
     Ok(Json(item))
 }

--- a/tests/it_logs.rs
+++ b/tests/it_logs.rs
@@ -126,3 +126,32 @@ async fn clear_logs_deletes_matching_rows() {
         "clear should remove all matching rows"
     );
 }
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn zero_and_oversized_page_size_are_rejected_not_panics() {
+    // LogQueryParams declared range(min = 1, max = 1000) but the handler never
+    // called validate(), so the bounds were inert. page_size=0 reached
+    // `total.div_ceil(0)` and SeaORM's `paginate(0)` — both panic on zero.
+    let app = TestApp::spawn().await;
+    let token = superuser_token();
+
+    for qs in ["page_size=0", "page_size=100000", "page=0"] {
+        let resp = app.get(&format!("/api/v3/logs?{qs}"), &token).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{qs} must be a 400, not a panic or an unbounded query; body: {}",
+            resp.text()
+        );
+    }
+
+    // A value inside the declared range still works.
+    let resp = app.get("/api/v3/logs?page_size=10&page=1", &token).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "an in-range page_size must still succeed; body: {}",
+        resp.text()
+    );
+}

--- a/tests/it_reports.rs
+++ b/tests/it_reports.rs
@@ -128,3 +128,45 @@ async fn create_report_with_invalid_body_is_rejected() {
         resp.text()
     );
 }
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn over_long_name_is_a_400_not_a_500() {
+    // GH #52: `Reports.Name` is varchar(30); a longer name used to reach the
+    // database and surface the truncation as a 500 with nothing the caller
+    // could act on. 30 characters must still be accepted — the boundary is
+    // exactly the column width.
+    let app = TestApp::spawn().await;
+    let token = superuser_token();
+
+    let resp = app
+        .post_json(
+            "/api/v3/reports",
+            &token,
+            &json!({ "name": "a".repeat(31) }),
+        )
+        .await;
+    assert_error(&resp, StatusCode::BAD_REQUEST, "INVALID_INPUT_ERROR");
+    assert!(
+        resp.text().contains("name"),
+        "the error must name the offending field; body: {}",
+        resp.text()
+    );
+
+    // The accepted boundary still works end to end.
+    let resp = app
+        .post_json(
+            "/api/v3/reports",
+            &token,
+            &json!({ "name": "b".repeat(30) }),
+        )
+        .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "30 characters must still be accepted; body: {}",
+        resp.text()
+    );
+    let created: ReportResponse = resp.json();
+    let _guard = RowGuard::report(created.id);
+}


### PR DESCRIPTION
Closes #52. Closes #38. Follow-up survey filed as #55.

## The reported bug

`POST /reports` returned 500 for a name longer than 30 characters. `Reports.Name` is `varchar(30)` (confirmed at `src/migration/.../tables.rs:3545`, `string_len(30)`), the DTO had **no validation at all**, and `src/error/mod.rs:337` maps every `DbErr` to a 500 unconditionally. So the truncation error surfaced as "A database error occurred" with nothing the caller could act on.

Both report DTOs now derive `Validate` and their handlers call it — an over-long name is a 400 naming the field, exactly the shape the issue asked for.

**One correction to the obvious fix:** garde's default `length(...)` counts **bytes** (`garde-0.22.1/src/rules/length/simple.rs:46`, `impl_via_bytes!(String)`), but `varchar(30)` is 30 *characters*. A plain `length(max = 30)` would reject a legitimate 30-character name containing any multi-byte character. This uses `length(chars, max = 30)`, with a test pinning the distinction (30 × `é` = 90 bytes, must validate).

## Five structs that derived `Validate` but were never validated

Checking how far the pattern spread turned up code that reads as validated and isn't. One of them was a **panic**, not just a missing 400:

`LogQueryParams` declares `range(min = 1, max = 1000)` on `page_size`, but `handlers/logs.rs` never called `validate()`. With the bound inert, `page_size=0` flowed to `total.div_ceil(0)` (`service/logs.rs:41`) and SeaORM's `paginate(0)`. I confirmed `div_ceil(0)` panics with "attempt to divide by zero" before fixing rather than assuming it. So `GET /api/v3/logs?page_size=0` was a panicking request, and a huge `page_size` pulled the whole table.

Also wired: `ConfigQueryParams` (same unbounded `page_size`), `UpdateStateRequest` and `AlarmControlRequest` (the service and shm layers happen to re-check these, so they were redundant rather than broken — but the contract should be enforced where it's declared), and `AiObjectClassQuery` (no live rules; wired for consistency with its six siblings).

## #38 — verified fixed, now guarded

The env-prefix bug was already fixed in code (`src/configure/env.rs:13` uses `.prefix_separator("_")`), but had **no regression test**, which is how it would have come back. Added two: one asserting the documented `APP_DB__HOST` resolves to `db.host`, one asserting the accidental `APP__DB__HOST` form does *not*, so the two spellings can't silently disagree about which wins. Both drive `Environment::source` rather than real environment variables, which are process-global and race other tests.

## Not fixed here — see #55

The survey found ~40 more request fields whose bounded columns have no matching rule (all of `groups`, `filters`, `users`, `monitor_presets`, `servers`, `storage`, `states`, `tags`, `models`, `zone_presets`, `object_types`, `snapshots`, `sessions`, `triggers_x10`, `user_preferences` have no `Validate` derive at all; `CreateMonitorRequest` derives it but leaves 26 bounded fields uncapped), plus the repo-wide bytes-vs-chars skew. That's a large mechanical change and it deserves a decision first — per-DTO rules versus catching MySQL 1406 centrally — so it's written up rather than bundled in.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — **867 passed, 0 failed** (274 DB-gated ignored). New unit tests cover the 30/31 boundary, the char-vs-byte semantics, the nullable case, and both env-prefix spellings; new DB-gated integration tests assert `POST /reports` returns 400 with the field named (and that 30 characters still returns 201), and that `page_size=0`, `page_size=100000` and `page=0` on `/logs` return 400 instead of panicking.