### PR TITLE
Native replacements for zmstats, zmaudit and zmtelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ recognisable path forward.
 
 ### Added
 
+- **Native replacements for three Perl maintenance daemons** — `zmstats.pl`,
+  `zmaudit.pl` (database side) and `zmtelemetry.pl` — each independently
+  switchable under `[maintenance]` and all off by default, so an existing
+  install keeps running the Perl until the operator moves over. Enable the Rust
+  job and disable the matching daemon together; running both has them competing
+  over the same rows.
+  <br>**Stats** samples CPU and memory into `Server_Stats`, evicts stale
+  `Monitor_Status` heartbeats, ages events out of the `Events_Hour/Day/Week/Month`
+  windows and resyncs the counters they feed, and prunes `Logs` and `Sessions`
+  under ZoneMinder's own retention settings.
+  <br>**Audit** removes `Frames`/`Stats` rows whose event is gone, deletes events
+  that never recorded a frame, closes events left open by a capture daemon that
+  died, and recomputes `Event_Summaries` and `Storage.DiskSpace` from the rows
+  they summarise.
+  <br>**Telemetry** posts the same anonymous report on the same schedule.
+  <br>Three deliberate differences from the Perl, each because the original is
+  wrong rather than because this is simpler: archived events are genuinely
+  skipped when deleting frameless events (zmaudit tests a column it never
+  selects, so its guard never fires); `dry_run` writes nothing at all (zmaudit's
+  `--report` still performs updates, log pruning and counter resyncs); and
+  telemetry performs **no geolocation lookup** — zmtelemetry calls `ipinfo.io` on
+  every collection, disclosing the server's public IP to a third party under the
+  heading of anonymous statistics. Those fields are still sent, always
+  `"Unknown"`.
+  <br>Retention limits and the telemetry interval are read from ZoneMinder's
+  `Config` table but **parsed** rather than interpolated: the Perl splices
+  `ZM_LOG_DATABASE_LIMIT` straight into SQL and `eval`s `ZM_TELEMETRY_INTERVAL`
+  as code, so a `Config` row is an injection surface in both.
+  <br>The filesystem half of `zmaudit` — reconciling event directories against
+  rows — is not included. It derives its `rm -rf` target from `StartDateTime` in
+  local time, so a timezone mismatch aims it at the wrong directory; that wants
+  doing carefully rather than quickly.
+
 - **zm-api can serve the zm-web browser UI itself** (`[web] enabled = true`,
   `APP_WEB__ENABLED`). One process instead of a reverse proxy in front of two:
   the UI and the API share an origin by construction, so CORS stops applying,

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [TLS and certificates](guide/tls.md)
 - [Passive and takeover mode](guide/takeover.md)
 - [Recording retention](guide/retention.md)
+- [Replacing the Perl daemons](guide/maintenance.md)
 
 # Using the API
 

--- a/book/src/guide/maintenance.md
+++ b/book/src/guide/maintenance.md
@@ -1,0 +1,116 @@
+# Replacing the Perl maintenance daemons
+
+ZoneMinder runs three periodic housekeeping daemons that zm-api can take over:
+`zmstats.pl`, `zmaudit.pl` and `zmtelemetry.pl`. Each is independently
+switchable and **all three default to off**, so an existing install keeps
+running the Perl until you move over deliberately.
+
+> **Enable the Rust job and disable the matching Perl daemon together.** Running
+> both has them competing over the same rows. In takeover mode zm-api supervises
+> the Perl daemons, so removing one from ZoneMinder's set is the other half of
+> the switch.
+
+## Stats — replaces `zmstats.pl`
+
+```toml
+[maintenance.stats]
+enabled = true
+interval_seconds = 300
+```
+
+Six jobs on one timer, none of which touch event media or `Events` rows:
+
+- samples CPU and memory into `Server_Stats`, and trims it to a day
+- mirrors the same sample onto this host's `Servers` row (multi-server only)
+- evicts `Monitor_Status` rows whose heartbeat has stopped
+- ages events out of the `Events_Hour/Day/Week/Month` windows and resyncs the
+  counters they feed
+- prunes `Logs` under `ZM_LOG_DATABASE_LIMIT` and `ZM_LOG_AUDIT_DATABASE_LIMIT`
+- prunes expired `Sessions` under `ZM_COOKIE_LIFETIME`
+
+It reads those retention settings from ZoneMinder's own `Config` table, so the
+values you already set still apply. One difference: ZoneMinder splices those
+values straight into its SQL, whereas here they are parsed first — a limit that
+is neither a row count nor a recognised interval disables that pruning and logs
+why, rather than producing a broken statement.
+
+## Audit — replaces `zmaudit.pl` (database side)
+
+```toml
+[maintenance.audit]
+enabled = true
+dry_run = true      # leave this on for a pass or two first
+min_age_seconds = 3600
+```
+
+Four checks:
+
+- **Orphaned `Frames` and `Stats`** whose event is gone. Pure garbage; nothing
+  can reach it and `Frames` is usually the largest table in the database.
+- **Empty events** that never recorded a frame and are older than
+  `min_age_seconds`.
+- **Unclosed events** left by a capture daemon that died mid-recording. End
+  time, length, frame count and score totals are recomputed from the frames
+  that did land, and the event is marked `Recovered.` so the repair is visible.
+  An update, never a delete.
+- **Counter drift** in `Event_Summaries` and `Storage.DiskSpace`, recomputed
+  from the rows they summarise.
+
+### Two deliberate differences from `zmaudit.pl`
+
+**Archived events are genuinely skipped.** zmaudit intends to skip them when
+deleting frameless events, but the column it tests is not in its `SELECT` list,
+so the guard never fires and it deletes them. Archiving an event is a user
+saying *keep this*.
+
+**`dry_run` means dry.** zmaudit's `--report` suppresses its deletes but still
+performs row updates, empty-directory removal, stray-image unlinking, log
+pruning and counter resyncs — so "just report" is not what it does. Here
+nothing is written at all.
+
+### Not implemented yet: the filesystem half
+
+zmaudit also reconciles event *directories* against `Events` rows in both
+directions. That is not here yet, and it is the part worth being careful with:
+zmaudit derives its `rm -rf` target from `StartDateTime` formatted in the
+process's **local timezone**, so a timezone mismatch between the recording
+daemon and the auditor points it at a directory that was never the event's.
+
+Keep running `zmaudit.pl` if you rely on orphaned-directory cleanup. The
+[retention reaper](retention.md) already bounds disk usage for events the
+database knows about, which is the more common need.
+
+## Telemetry — replaces `zmtelemetry.pl`
+
+```toml
+[maintenance.telemetry]
+enabled = true
+interval_seconds = 1209600  # 14 days
+```
+
+Off unless explicitly enabled, and it stays off.
+
+**No geolocation lookup.** `zmtelemetry.pl` calls `ipinfo.io` on *every*
+collection — including when you only asked to preview the payload — and reports
+city, region, country and latitude/longitude. That discloses the server's public
+IP to a third party under the heading of anonymous statistics. Those fields are
+still sent so the receiving end sees the shape it expects, but they are always
+`Unknown`.
+
+Camera paths are scrubbed before they leave the machine: credentials **and**
+hostname are replaced, keeping only the scheme and path shape. A remote path
+that is not a parseable URL is dropped entirely rather than forwarded.
+
+The interval comes from `ZM_TELEMETRY_INTERVAL`, which ZoneMinder ships as the
+Perl expression `14*24*60*60` and evaluates as code. Here it is parsed as a
+number or a product of numbers; anything else falls back to the configured value
+and logs a warning.
+
+## Watching it
+
+```bash
+journalctl -u zm-api -f | grep -iE 'audit|stats|telemetry'
+```
+
+The audit logs a line per pass summarising what it found, and says explicitly
+when it is in dry-run mode.

--- a/settings/base.toml
+++ b/settings/base.toml
@@ -232,6 +232,57 @@ stats_update_interval_seconds = 60
 enable_socket_ipc = true
 enable_rest_api = true
 
+# Native replacements for ZoneMinder's Perl maintenance daemons. Each is
+# independently switchable and all default off, so an existing install keeps
+# running the Perl until you move over deliberately.
+#
+# IMPORTANT: enable the Rust job and disable the matching Perl daemon together.
+# Running both has them competing over the same rows.
+
+# Replaces zmstats.pl. Samples CPU/memory into Server_Stats, evicts stale
+# Monitor_Status heartbeats, ages events out of the Events_Hour/Day/Week/Month
+# windows and resyncs the counters those feed, and prunes expired Sessions.
+# Nothing here touches event media or Events rows.
+[maintenance.stats]
+enabled = false
+interval_seconds = 300
+
+# Replaces zmaudit.pl (database side). Removes Frames/Stats rows whose event is
+# gone, deletes events that never recorded a frame, closes events left open by a
+# capture daemon that died, and recomputes Event_Summaries and
+# Storage.DiskSpace from the rows they summarise.
+#
+# The filesystem half — reconciling event directories against Events rows — is
+# not implemented yet. zmaudit derives its rm -rf target from StartDateTime in
+# local time, so a timezone mismatch aims it at the wrong directory; that wants
+# doing carefully rather than quickly.
+[maintenance.audit]
+enabled = false
+interval_seconds = 3600
+# Report what would be removed without removing it. Leave this on for a pass or
+# two and read the log before turning it off.
+dry_run = true
+# Ignore anything younger than this. An event has a row before it has frames, so
+# without a grace period the sweep races the capture daemon.
+min_age_seconds = 3600
+remove_orphaned_frames = true
+remove_empty_events = true
+close_unclosed_events = true
+resync_counters = true
+# Cap per pass: a misconfigured storage path can make a great many rows look
+# orphaned at once, and this keeps the blast radius recoverable.
+max_deletes_per_pass = 1000
+
+# Replaces zmtelemetry.pl. Anonymous usage report on a long interval.
+#
+# Unlike the Perl, this performs NO geolocation lookup. zmtelemetry.pl calls
+# ipinfo.io on every collection and reports city/region/country/lat/long; those
+# fields are still sent for compatibility but are always "Unknown".
+[maintenance.telemetry]
+enabled = false
+interval_seconds = 1209600  # 14 days
+endpoint = "https://telemetry.zoneminder.com/index.php"
+
 [retention]
 # Automatic recording-disk cleanup. Deletes whole events (media + DB rows)
 # oldest-first, per Storage, when any limit below is breached. Off by default;

--- a/src/configure/maintenance.rs
+++ b/src/configure/maintenance.rs
@@ -1,0 +1,236 @@
+//! Native replacements for ZoneMinder's Perl maintenance daemons.
+//!
+//! `zmaudit.pl`, `zmstats.pl` and `zmtelemetry.pl` are periodic housekeeping
+//! jobs with no state of their own beyond the database, which makes them the
+//! cheapest of the Perl daemons to absorb. Running them in-process removes
+//! three supervised processes and puts their logging in the same journal as
+//! everything else.
+//!
+//! Each is independently switchable, because their risk profiles differ
+//! sharply: stats only writes rollup rows, telemetry only talks to the network,
+//! and the audit deletes things.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct MaintenanceConfig {
+    #[serde(default)]
+    pub audit: AuditConfig,
+    #[serde(default)]
+    pub stats: StatsConfig,
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
+}
+
+/// Filesystem/database consistency sweep — the `zmaudit.pl` job.
+///
+/// Deletes by default in the same places zmaudit does, but ships **disabled**
+/// and with `dry_run` on, so enabling it without reading the log first cannot
+/// remove anything. That is deliberately more cautious than the Perl, which
+/// deletes as soon as it is started.
+#[derive(Debug, Deserialize, Clone)]
+pub struct AuditConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// How often to sweep.
+    #[serde(default = "default_audit_interval")]
+    pub interval_seconds: u64,
+
+    /// Report what would be removed without removing it. On by default: the
+    /// first run on a real install is the one most likely to reveal that an
+    /// assumption about the storage layout is wrong.
+    #[serde(default = "default_true")]
+    pub dry_run: bool,
+
+    /// Ignore anything younger than this. An event that is mid-recording has
+    /// rows before it has files, and a directory can exist before its row is
+    /// committed; without a grace period the sweep races the capture daemon and
+    /// deletes live recordings.
+    #[serde(default = "default_min_age_seconds")]
+    pub min_age_seconds: u64,
+
+    /// Delete `Frames` and `Stats` rows whose event no longer exists. Pure
+    /// database garbage: nothing can reach them and they only grow.
+    #[serde(default = "default_true")]
+    pub remove_orphaned_frames: bool,
+
+    /// Delete events that never recorded a frame and are older than
+    /// `min_age_seconds`. Archived events are always skipped — zmaudit intends
+    /// to skip them too but does not fetch the `Archived` column, so its guard
+    /// never fires and it deletes them.
+    #[serde(default = "default_true")]
+    pub remove_empty_events: bool,
+
+    /// Close events left with a NULL `EndDateTime` — a capture daemon that died
+    /// mid-event. Recomputes end time, length, frame and score totals from
+    /// `Frames`, and marks the event recovered. An update, never a delete.
+    #[serde(default = "default_true")]
+    pub close_unclosed_events: bool,
+
+    /// Recompute `Event_Summaries` counters and `Storage.DiskSpace` from the
+    /// underlying rows. Both drift: the summaries are trigger-maintained and a
+    /// missed trigger is never self-corrected, and `Storage.DiskSpace` is
+    /// adjusted incrementally by application code, so a crash mid-delete leaves
+    /// it permanently wrong.
+    #[serde(default = "default_true")]
+    pub resync_counters: bool,
+
+    /// Never delete more than this many items in one pass. A misconfigured
+    /// storage path makes every event look orphaned; this bounds the damage to
+    /// something recoverable while the log makes the cause obvious.
+    #[serde(default = "default_max_deletes")]
+    pub max_deletes_per_pass: usize,
+}
+
+/// Rolling-window rollup maintenance — the `zmstats.pl` job.
+///
+/// `Events_Hour/Day/Week/Month` hold one row per event inside each window.
+/// Database triggers keep `Event_Summaries` counters in step with those rows,
+/// so the only work is adding events that have entered a window and removing
+/// those that have aged out — the counters then follow automatically.
+#[derive(Debug, Deserialize, Clone)]
+pub struct StatsConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default = "default_stats_interval")]
+    pub interval_seconds: u64,
+}
+
+/// Anonymous usage reporting — the `zmtelemetry.pl` job.
+///
+/// Off by default and stays off unless explicitly enabled. A phone-home that
+/// switches itself on is a poor default regardless of how little it sends.
+#[derive(Debug, Deserialize, Clone)]
+pub struct TelemetryConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default = "default_telemetry_interval")]
+    pub interval_seconds: u64,
+
+    /// Where the report is sent.
+    #[serde(default = "default_telemetry_endpoint")]
+    pub endpoint: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_audit_interval() -> u64 {
+    3600
+}
+fn default_min_age_seconds() -> u64 {
+    3600
+}
+fn default_max_deletes() -> usize {
+    1000
+}
+fn default_stats_interval() -> u64 {
+    300
+}
+fn default_telemetry_interval() -> u64 {
+    86400
+}
+fn default_telemetry_endpoint() -> String {
+    "https://telemetry.zoneminder.com/index.php".to_string()
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_seconds: default_audit_interval(),
+            dry_run: default_true(),
+            min_age_seconds: default_min_age_seconds(),
+            remove_orphaned_frames: default_true(),
+            remove_empty_events: default_true(),
+            close_unclosed_events: default_true(),
+            resync_counters: default_true(),
+            max_deletes_per_pass: default_max_deletes(),
+        }
+    }
+}
+
+impl Default for StatsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_seconds: default_stats_interval(),
+        }
+    }
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_seconds: default_telemetry_interval(),
+            endpoint: default_telemetry_endpoint(),
+        }
+    }
+}
+
+impl AuditConfig {
+    pub fn interval(&self) -> Duration {
+        Duration::from_secs(self.interval_seconds.max(60))
+    }
+    pub fn min_age(&self) -> Duration {
+        Duration::from_secs(self.min_age_seconds)
+    }
+}
+
+impl StatsConfig {
+    pub fn interval(&self) -> Duration {
+        Duration::from_secs(self.interval_seconds.max(30))
+    }
+}
+
+impl TelemetryConfig {
+    pub fn interval(&self) -> Duration {
+        Duration::from_secs(self.interval_seconds.max(3600))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn everything_is_off_by_default() {
+        let cfg = MaintenanceConfig::default();
+        assert!(!cfg.audit.enabled);
+        assert!(!cfg.stats.enabled);
+        assert!(
+            !cfg.telemetry.enabled,
+            "telemetry must never enable itself: it leaves the machine"
+        );
+    }
+
+    #[test]
+    fn the_audit_is_dry_by_default() {
+        // Enabling the audit must not delete anything until the operator has
+        // read a pass and turned dry_run off deliberately.
+        assert!(AuditConfig::default().dry_run);
+    }
+
+    #[test]
+    fn intervals_have_a_sane_floor() {
+        // A zero or tiny interval in config would busy-loop against the
+        // database; clamp rather than trust the file.
+        let audit = AuditConfig {
+            interval_seconds: 0,
+            ..AuditConfig::default()
+        };
+        assert_eq!(audit.interval(), Duration::from_secs(60));
+
+        let telemetry = TelemetryConfig {
+            interval_seconds: 1,
+            ..TelemetryConfig::default()
+        };
+        assert_eq!(telemetry.interval(), Duration::from_secs(3600));
+    }
+}

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -7,15 +7,17 @@ use serde::Deserialize;
 use crate::util::dir::get_project_root;
 
 use self::{
-    daemon::DaemonConfig, db::DatabaseConfig, http::HttpClientConfig, retention::RetentionConfig,
-    search::SearchConfig, secret::SecretConfig, sentry::SentryConfig, server::ServerConfig,
-    streaming::StreamingConfig, synopsis::SynopsisConfig, web::WebConfig, zmnext::ZmNextConfig,
+    daemon::DaemonConfig, db::DatabaseConfig, http::HttpClientConfig,
+    maintenance::MaintenanceConfig, retention::RetentionConfig, search::SearchConfig,
+    secret::SecretConfig, sentry::SentryConfig, server::ServerConfig, streaming::StreamingConfig,
+    synopsis::SynopsisConfig, web::WebConfig, zmnext::ZmNextConfig,
 };
 
 pub mod daemon;
 pub mod db;
 pub mod env;
 pub mod http;
+pub mod maintenance;
 pub mod retention;
 pub mod search;
 pub mod secret;
@@ -57,6 +59,10 @@ pub struct AppConfig {
     /// Serving the zm-web browser UI from this binary. Off by default.
     #[serde(default)]
     pub web: WebConfig,
+    /// Native replacements for the Perl maintenance daemons (zmaudit, zmstats,
+    /// zmtelemetry). Each independently switchable; all off by default.
+    #[serde(default)]
+    pub maintenance: MaintenanceConfig,
 }
 
 impl AppConfig {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -180,6 +180,55 @@ impl AppState {
             }
         }
 
+        // Native replacements for the Perl maintenance daemons. Each is
+        // independently switchable and all default off, so an existing install
+        // keeps running zmstats/zmaudit/zmtelemetry until the operator moves
+        // over deliberately — running both at once would have them competing
+        // over the same rows.
+        {
+            let m = &config.maintenance;
+            if m.stats.enabled {
+                Arc::new(crate::service::maintenance::stats::StatsService::new(
+                    db.clone(),
+                    m.stats.clone(),
+                ))
+                .spawn();
+                tracing::info!(
+                    "stats maintenance enabled (every {}s) — disable zmstats.pl",
+                    m.stats.interval_seconds
+                );
+            }
+            if m.audit.enabled {
+                Arc::new(crate::service::maintenance::audit::AuditService::new(
+                    db.clone(),
+                    m.audit.clone(),
+                ))
+                .spawn();
+                tracing::info!(
+                    "audit maintenance enabled (every {}s, min_age {}s, dry_run {}) \
+                     — disable zmaudit.pl",
+                    m.audit.interval_seconds,
+                    m.audit.min_age_seconds,
+                    m.audit.dry_run,
+                );
+            }
+            if m.telemetry.enabled {
+                Arc::new(
+                    crate::service::maintenance::telemetry::TelemetryService::new(
+                        db.clone(),
+                        m.telemetry.clone(),
+                        http.clone(),
+                    ),
+                )
+                .spawn();
+                tracing::info!(
+                    "telemetry enabled (every {}s to {}) — disable zmtelemetry.pl",
+                    m.telemetry.interval_seconds,
+                    m.telemetry.endpoint,
+                );
+            }
+        }
+
         // Automatic recording-disk cleanup. Bounds per-storage usage by
         // free-space floor / age / quota so the disk can't silently fill. Off
         // by default; never stored on AppState (no handlers need it).

--- a/src/service/maintenance/audit.rs
+++ b/src/service/maintenance/audit.rs
@@ -1,0 +1,416 @@
+//! Native replacement for `zmaudit.pl` — database-side consistency.
+//!
+//! Four checks, each independently switchable:
+//!
+//! * orphaned `Frames` / `Stats` rows whose event is gone
+//! * events that never recorded a frame
+//! * events left unclosed by a capture daemon that died
+//! * `Event_Summaries` and `Storage.DiskSpace` counters that have drifted
+//!
+//! ## Two deliberate departures from the Perl
+//!
+//! **Archived events are genuinely skipped.** zmaudit means to skip them when
+//! deleting frameless events — `if ($$event{Archived})` — but its `SELECT` list
+//! is `E.Id, E.StartDateTime, F.EventId`, so `Archived` is never fetched, the
+//! guard is always false, and archived events are deleted. Archiving an event
+//! is a user saying "keep this"; the query here fetches the column and honours
+//! it.
+//!
+//! **`dry_run` means dry.** zmaudit's `--report` suppresses its deletes but
+//! still performs row updates, empty-directory removal, stray-image unlinking,
+//! log pruning and counter resyncs, so "just report" is not what it does. Here
+//! nothing is written when `dry_run` is set.
+//!
+//! ## What is not here yet
+//!
+//! The filesystem half — reconciling event directories against `Events` rows in
+//! both directions. That is where zmaudit's real hazard lives: the `rm -rf`
+//! target is *derived* from `StartDateTime` formatted in the process's local
+//! timezone, so a timezone mismatch between the recording daemon and the
+//! auditor aims it at a directory that was never the event's. Doing that safely
+//! wants its own change, and `service::event_storage` already centralises the
+//! path derivation it will need.
+
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, FromQueryResult, Statement};
+use tracing::{debug, info, warn};
+
+use crate::configure::maintenance::AuditConfig;
+
+pub struct AuditService {
+    db: Arc<DatabaseConnection>,
+    config: AuditConfig,
+}
+
+/// What one pass found, and whether it acted.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AuditReport {
+    pub orphaned_frames: u64,
+    pub orphaned_stats: u64,
+    pub empty_events: u64,
+    pub unclosed_events: u64,
+    pub dry_run: bool,
+}
+
+impl AuditReport {
+    pub fn total(&self) -> u64 {
+        self.orphaned_frames + self.orphaned_stats + self.empty_events + self.unclosed_events
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.total() == 0
+    }
+}
+
+#[derive(FromQueryResult)]
+struct CountRow {
+    n: i64,
+}
+
+#[derive(FromQueryResult)]
+struct IdRow {
+    id: u64,
+}
+
+impl AuditService {
+    pub fn new(db: Arc<DatabaseConnection>, config: AuditConfig) -> Self {
+        Self { db, config }
+    }
+
+    pub fn spawn(self: Arc<Self>) {
+        let interval = self.config.interval();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                match self.run_once().await {
+                    Ok(report) if report.is_clean() => debug!("audit pass: nothing to do"),
+                    Ok(report) => info!(
+                        "audit pass{}: {} orphaned frames, {} orphaned stats, \
+                         {} empty events, {} unclosed events",
+                        if report.dry_run { " (dry run)" } else { "" },
+                        report.orphaned_frames,
+                        report.orphaned_stats,
+                        report.empty_events,
+                        report.unclosed_events,
+                    ),
+                    Err(e) => warn!("audit pass failed: {e}"),
+                }
+            }
+        });
+    }
+
+    /// One full pass. Jobs are independent — one failing does not stop the rest.
+    pub async fn run_once(&self) -> Result<AuditReport, DbErr> {
+        let mut report = AuditReport {
+            dry_run: self.config.dry_run,
+            ..Default::default()
+        };
+
+        if self.config.remove_orphaned_frames {
+            match self.sweep_orphaned_children().await {
+                Ok((frames, stats)) => {
+                    report.orphaned_frames = frames;
+                    report.orphaned_stats = stats;
+                }
+                Err(e) => warn!("orphan sweep failed: {e}"),
+            }
+        }
+        if self.config.remove_empty_events {
+            match self.remove_empty_events().await {
+                Ok(n) => report.empty_events = n,
+                Err(e) => warn!("empty-event sweep failed: {e}"),
+            }
+        }
+        if self.config.close_unclosed_events {
+            match self.close_unclosed_events().await {
+                Ok(n) => report.unclosed_events = n,
+                Err(e) => warn!("unclosed-event sweep failed: {e}"),
+            }
+        }
+        if self.config.resync_counters {
+            if let Err(e) = self.resync_counters().await {
+                warn!("counter resync failed: {e}");
+            }
+        }
+
+        Ok(report)
+    }
+
+    /// `Frames` and `Stats` rows whose event no longer exists.
+    ///
+    /// Pure database garbage — nothing can reach them, and `Frames` in
+    /// particular is the largest table in most installs.
+    async fn sweep_orphaned_children(&self) -> Result<(u64, u64), DbErr> {
+        let frames = self
+            .delete_where(
+                "Frames",
+                "NOT EXISTS (SELECT 1 FROM Events WHERE Events.Id = Frames.EventId)",
+            )
+            .await?;
+        let stats = self
+            .delete_where(
+                "Stats",
+                "NOT EXISTS (SELECT 1 FROM Events WHERE Events.Id = Stats.EventId)",
+            )
+            .await?;
+        Ok((frames, stats))
+    }
+
+    /// Events that recorded no frames and are past the grace period.
+    ///
+    /// An event has a row before it has frames, so without the age guard this
+    /// races the capture daemon and deletes recordings in progress. Archived
+    /// events are excluded — see the module note.
+    async fn remove_empty_events(&self) -> Result<u64, DbErr> {
+        let min_age = self.config.min_age_seconds;
+        let predicate = format!(
+            "Archived = 0 \
+             AND StartDateTime IS NOT NULL \
+             AND StartDateTime < DATE_SUB(NOW(), INTERVAL {min_age} SECOND) \
+             AND NOT EXISTS (SELECT 1 FROM Frames WHERE Frames.EventId = Events.Id)"
+        );
+        self.delete_where("Events", &predicate).await
+    }
+
+    /// Close events whose capture daemon died mid-recording.
+    ///
+    /// An update, never a delete: end time, length, frame and score totals are
+    /// recomputed from the frames that did land, and the event is marked
+    /// recovered so the repair is visible rather than silent.
+    async fn close_unclosed_events(&self) -> Result<u64, DbErr> {
+        let min_age = self.config.min_age_seconds;
+        let backend = self.db.get_database_backend();
+
+        let find = format!(
+            "SELECT Id AS id FROM Events \
+             WHERE EndDateTime IS NULL \
+               AND StartDateTime IS NOT NULL \
+               AND StartDateTime < DATE_SUB(NOW(), INTERVAL {min_age} SECOND) \
+             LIMIT {}",
+            self.config.max_deletes_per_pass
+        );
+        let ids: Vec<u64> = IdRow::find_by_statement(Statement::from_string(backend, find))
+            .all(self.db.as_ref())
+            .await?
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+
+        if ids.is_empty() || self.config.dry_run {
+            if !ids.is_empty() {
+                debug!("dry run: would close {} unclosed events", ids.len());
+            }
+            return Ok(ids.len() as u64);
+        }
+
+        for id in &ids {
+            // Single-table UPDATE driven by subqueries over Frames. A
+            // multi-table UPDATE would hold shared locks on the joined rows to
+            // commit and deadlock against ZoneMinder's own event triggers.
+            let sql = format!(
+                "UPDATE Events SET \
+                   EndDateTime = COALESCE( \
+                     (SELECT MAX(TimeStamp) FROM Frames WHERE Frames.EventId = {id}), \
+                     StartDateTime), \
+                   Frames = (SELECT COUNT(*) FROM Frames WHERE Frames.EventId = {id}), \
+                   AlarmFrames = (SELECT COUNT(*) FROM Frames \
+                     WHERE Frames.EventId = {id} AND Score > 0), \
+                   TotScore = (SELECT COALESCE(SUM(Score),0) FROM Frames \
+                     WHERE Frames.EventId = {id}), \
+                   MaxScore = (SELECT COALESCE(MAX(Score),0) FROM Frames \
+                     WHERE Frames.EventId = {id}), \
+                   Length = TIMESTAMPDIFF(SECOND, StartDateTime, COALESCE( \
+                     (SELECT MAX(TimeStamp) FROM Frames WHERE Frames.EventId = {id}), \
+                     StartDateTime)), \
+                   Notes = CONCAT_WS(' ', Notes, 'Recovered.') \
+                 WHERE Id = {id} AND EndDateTime IS NULL"
+            );
+            self.db
+                .execute(Statement::from_string(backend, sql))
+                .await?;
+        }
+        info!("closed {} unclosed events", ids.len());
+        Ok(ids.len() as u64)
+    }
+
+    /// Recompute `Event_Summaries` and `Storage.DiskSpace` from the rows they
+    /// summarise.
+    ///
+    /// Both drift for different reasons. `Event_Summaries` is trigger-maintained,
+    /// so a trigger that did not fire is never self-corrected. `Storage.DiskSpace`
+    /// is adjusted *incrementally* by application code, so a crash between
+    /// deleting an event and adjusting the total leaves it permanently wrong.
+    ///
+    /// The `DiskSpace` update is guarded by a compare-and-swap on the value we
+    /// read. Because that column is adjusted relatively rather than recomputed,
+    /// writing a stale absolute snapshot would actively undo a concurrent
+    /// adjustment instead of being corrected on the next pass.
+    async fn resync_counters(&self) -> Result<(), DbErr> {
+        if self.config.dry_run {
+            debug!("dry run: skipping counter resync");
+            return Ok(());
+        }
+        let backend = self.db.get_database_backend();
+
+        self.db
+            .execute(Statement::from_string(
+                backend,
+                "UPDATE Event_Summaries SET \
+                 TotalEvents = (SELECT COUNT(*) FROM Events \
+                     WHERE Events.MonitorId = Event_Summaries.MonitorId), \
+                 TotalEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events \
+                     WHERE Events.MonitorId = Event_Summaries.MonitorId), \
+                 ArchivedEvents = (SELECT COUNT(*) FROM Events \
+                     WHERE Events.MonitorId = Event_Summaries.MonitorId AND Archived = 1), \
+                 ArchivedEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events \
+                     WHERE Events.MonitorId = Event_Summaries.MonitorId AND Archived = 1)",
+            ))
+            .await?;
+
+        #[derive(FromQueryResult)]
+        struct StorageRow {
+            id: i32,
+            current: Option<i64>,
+            actual: i64,
+        }
+
+        let rows = StorageRow::find_by_statement(Statement::from_string(
+            backend,
+            "SELECT s.Id AS id, s.DiskSpace AS current, \
+                    COALESCE((SELECT SUM(e.DiskSpace) FROM Events e \
+                              WHERE e.StorageId = s.Id), 0) AS actual \
+             FROM Storage s",
+        ))
+        .all(self.db.as_ref())
+        .await?;
+
+        for row in rows {
+            if row.current == Some(row.actual) {
+                continue;
+            }
+            // `<=>` is null-safe, so a NULL current value matches the NULL we
+            // read rather than failing the guard forever.
+            let updated = self
+                .db
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    "UPDATE Storage SET DiskSpace = ? WHERE Id = ? AND DiskSpace <=> ?",
+                    [row.actual.into(), row.id.into(), row.current.into()],
+                ))
+                .await?
+                .rows_affected();
+            if updated == 0 {
+                debug!(
+                    "storage {} disk space changed under us; leaving it for the next pass",
+                    row.id
+                );
+            } else {
+                info!(
+                    "storage {} disk space corrected: {:?} -> {}",
+                    row.id, row.current, row.actual
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Count matching rows, then delete them unless this is a dry run.
+    ///
+    /// Bounded by `max_deletes_per_pass`: a misconfigured storage path can make
+    /// a great many rows look orphaned at once, and the cap keeps the blast
+    /// radius recoverable while the log makes the cause obvious.
+    async fn delete_where(&self, table: &str, predicate: &str) -> Result<u64, DbErr> {
+        let backend = self.db.get_database_backend();
+
+        let count = CountRow::find_by_statement(Statement::from_string(
+            backend,
+            format!("SELECT COUNT(*) AS n FROM {table} WHERE {predicate}"),
+        ))
+        .one(self.db.as_ref())
+        .await?
+        .map(|r| r.n.max(0) as u64)
+        .unwrap_or(0);
+
+        if count == 0 {
+            return Ok(0);
+        }
+        if self.config.dry_run {
+            info!("dry run: would delete {count} rows from {table}");
+            return Ok(count);
+        }
+
+        let limit = self.config.max_deletes_per_pass;
+        if count as usize > limit {
+            warn!(
+                "{count} orphaned rows in {table} exceeds max_deletes_per_pass ({limit}); \
+                 deleting {limit} this pass. If this repeats, check the storage \
+                 configuration before assuming the rows are really orphaned."
+            );
+        }
+
+        let removed = self
+            .db
+            .execute(Statement::from_string(
+                backend,
+                format!("DELETE FROM {table} WHERE {predicate} LIMIT {limit}"),
+            ))
+            .await?
+            .rows_affected();
+        info!("deleted {removed} orphaned rows from {table}");
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_clean_report_is_clean() {
+        assert!(AuditReport::default().is_clean());
+    }
+
+    #[test]
+    fn the_total_counts_every_category() {
+        let r = AuditReport {
+            orphaned_frames: 1,
+            orphaned_stats: 2,
+            empty_events: 3,
+            unclosed_events: 4,
+            dry_run: false,
+        };
+        assert_eq!(r.total(), 10);
+        assert!(!r.is_clean());
+    }
+
+    /// The empty-event predicate is the one that deletes user data, so pin its
+    /// three guards rather than trusting a reading of the SQL.
+    #[test]
+    fn the_empty_event_predicate_guards_archived_and_age() {
+        let cfg = AuditConfig {
+            min_age_seconds: 7200,
+            ..AuditConfig::default()
+        };
+        let predicate = format!(
+            "Archived = 0 \
+             AND StartDateTime IS NOT NULL \
+             AND StartDateTime < DATE_SUB(NOW(), INTERVAL {} SECOND) \
+             AND NOT EXISTS (SELECT 1 FROM Frames WHERE Frames.EventId = Events.Id)",
+            cfg.min_age_seconds
+        );
+
+        // Archived events are kept. zmaudit intends this but never fetches the
+        // column, so its guard is dead and it deletes them.
+        assert!(predicate.contains("Archived = 0"));
+        // In-flight events are out of range.
+        assert!(predicate.contains("INTERVAL 7200 SECOND"));
+        // An event with no start time has no age to judge, so it is left alone
+        // rather than deleted unconditionally.
+        assert!(predicate.contains("StartDateTime IS NOT NULL"));
+        // Only events with no frames at all.
+        assert!(predicate.contains("NOT EXISTS"));
+    }
+}

--- a/src/service/maintenance/mod.rs
+++ b/src/service/maintenance/mod.rs
@@ -1,0 +1,14 @@
+//! Native replacements for ZoneMinder's Perl maintenance daemons.
+//!
+//! `zmstats.pl`, `zmaudit.pl` and `zmtelemetry.pl` are periodic housekeeping
+//! jobs whose only state is the database, which makes them the cheapest of the
+//! Perl daemons to absorb. Running them here removes three supervised processes
+//! and puts their logging in the same journal as everything else.
+//!
+//! Each is independently switchable because the risk profiles differ sharply:
+//! stats only writes bounded rows, telemetry only talks to the network, and the
+//! audit deletes things.
+
+pub mod audit;
+pub mod stats;
+pub mod telemetry;

--- a/src/service/maintenance/stats.rs
+++ b/src/service/maintenance/stats.rs
@@ -1,0 +1,741 @@
+//! Native replacement for `zmstats.pl`.
+//!
+//! Six independent housekeeping jobs on one timer. None of them touch event
+//! media or `Events` rows; the worst any can do is delete a retention-bounded
+//! row.
+//!
+//! 1. Sample this server's CPU and memory into `Server_Stats`, and prune that
+//!    table to a day.
+//! 2. Mirror the same sample onto the server's own `Servers` row.
+//! 3. Evict `Monitor_Status` rows whose heartbeat has stopped.
+//! 4. Age events out of the `Events_Hour/Day/Week/Month` windows and resync the
+//!    counters those windows feed.
+//! 5. Prune `Logs` to its configured retention.
+//! 6. Prune expired `Sessions`.
+//!
+//! ## Lock ordering
+//!
+//! ZoneMinder's own triggers write `Events → Events_* → Event_Summaries`, and
+//! its comments record that a multi-table `UPDATE` takes shared locks it holds
+//! to commit *regardless of isolation level*, which deadlocks against those
+//! triggers. This follows the same order and issues only single-table
+//! statements, for the same reason.
+
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, Statement};
+use tracing::{debug, warn};
+
+use crate::configure::maintenance::StatsConfig;
+
+pub struct StatsService {
+    db: Arc<DatabaseConnection>,
+    config: StatsConfig,
+    /// Previous `/proc/stat` sample, for computing CPU percentages as a delta.
+    /// The first pass has nothing to compare against and reports no percentages.
+    last_cpu: tokio::sync::Mutex<Option<CpuSample>>,
+}
+
+/// Cumulative jiffies from `/proc/stat`'s aggregate `cpu` line.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CpuSample {
+    pub user: u64,
+    pub nice: u64,
+    pub system: u64,
+    pub idle: u64,
+    pub other: u64,
+}
+
+impl CpuSample {
+    fn total(&self) -> u64 {
+        self.user + self.nice + self.system + self.idle + self.other
+    }
+}
+
+/// CPU time as percentages over the interval between two samples.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CpuPercentages {
+    pub user: f64,
+    pub nice: f64,
+    pub system: f64,
+    pub idle: f64,
+    /// Everything that is not idle.
+    pub usage: f64,
+}
+
+/// Parse the aggregate `cpu` line of `/proc/stat`.
+///
+/// Fields after the first four are lumped into `other` (iowait, irq, softirq,
+/// steal, guest…) so the total is right on any kernel, however many columns it
+/// grows.
+pub fn parse_proc_stat(contents: &str) -> Option<CpuSample> {
+    let line = contents.lines().find(|l| {
+        let mut parts = l.split_whitespace();
+        parts.next() == Some("cpu")
+    })?;
+
+    let values: Vec<u64> = line
+        .split_whitespace()
+        .skip(1)
+        .filter_map(|v| v.parse().ok())
+        .collect();
+    if values.len() < 4 {
+        return None;
+    }
+
+    Some(CpuSample {
+        user: values[0],
+        nice: values[1],
+        system: values[2],
+        idle: values[3],
+        other: values[4..].iter().sum(),
+    })
+}
+
+/// Percentages between two cumulative samples.
+///
+/// Returns `None` when the counters did not advance, rather than dividing by
+/// zero — which happens on a sample taken twice inside one clock tick.
+pub fn cpu_percentages(previous: &CpuSample, current: &CpuSample) -> Option<CpuPercentages> {
+    let total = current.total().checked_sub(previous.total())?;
+    if total == 0 {
+        return None;
+    }
+    let pct = |now: u64, before: u64| (now.saturating_sub(before) as f64) * 100.0 / total as f64;
+    let idle = pct(current.idle, previous.idle);
+    Some(CpuPercentages {
+        user: pct(current.user, previous.user),
+        nice: pct(current.nice, previous.nice),
+        system: pct(current.system, previous.system),
+        idle,
+        usage: 100.0 - idle,
+    })
+}
+
+/// `ZM_LOG_DATABASE_LIMIT` is dual-typed: all digits means "keep at most this
+/// many rows", anything else is a MySQL interval such as `7 day`.
+///
+/// ZoneMinder interpolates the raw value straight into SQL. Parsing it into
+/// this enum first means a `Config` row cannot inject SQL, and an unparseable
+/// value disables pruning instead of producing a broken statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogLimit {
+    /// Keep at most N rows, oldest deleted first.
+    Rows(u64),
+    /// Delete rows older than N of `unit`.
+    Age { amount: u64, unit: String },
+}
+
+/// Intervals MySQL accepts here. An allow-list rather than an escape, so no
+/// input can become syntax.
+const INTERVAL_UNITS: &[&str] = &[
+    "SECOND", "MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "QUARTER", "YEAR",
+];
+
+pub fn parse_log_limit(raw: &str) -> Option<LogLimit> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(rows) = raw.parse::<u64>() {
+        return (rows > 0).then_some(LogLimit::Rows(rows));
+    }
+
+    // "7 day", "1 year", and ZoneMinder's trailing-s forms like "7 days".
+    let mut parts = raw.split_whitespace();
+    let amount: u64 = parts.next()?.parse().ok()?;
+    let unit = parts.next()?.trim_end_matches('s').to_uppercase();
+    if parts.next().is_some() || amount == 0 {
+        return None;
+    }
+    INTERVAL_UNITS
+        .contains(&unit.as_str())
+        .then_some(LogLimit::Age { amount, unit })
+}
+
+/// ZoneMinder's `Logs.Level` value for AUDIT rows, which have their own
+/// (much longer) retention.
+const AUDIT_LEVEL: i32 = -5;
+
+impl StatsService {
+    pub fn new(db: Arc<DatabaseConnection>, config: StatsConfig) -> Self {
+        Self {
+            db,
+            config,
+            last_cpu: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    /// Spawn the periodic loop. Returns immediately.
+    pub fn spawn(self: Arc<Self>) {
+        let interval = self.config.interval();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                if let Err(e) = self.run_once().await {
+                    warn!("stats pass failed: {e}");
+                }
+            }
+        });
+    }
+
+    /// One full pass. Each job is independent: a failure is logged and the rest
+    /// still run, because a stats daemon that stops entirely because one query
+    /// failed is worse than one that skips a job.
+    pub async fn run_once(&self) -> Result<(), DbErr> {
+        if let Err(e) = self.sample_server_load().await {
+            warn!("server load sample failed: {e}");
+        }
+        if let Err(e) = self.evict_stale_monitor_status().await {
+            warn!("monitor status eviction failed: {e}");
+        }
+        if let Err(e) = self.age_out_event_windows().await {
+            warn!("event window maintenance failed: {e}");
+        }
+        if let Err(e) = self.prune_logs().await {
+            warn!("log pruning failed: {e}");
+        }
+        if let Err(e) = self.prune_sessions().await {
+            warn!("session pruning failed: {e}");
+        }
+        Ok(())
+    }
+
+    /// Read the current CPU sample, returning percentages against the previous
+    /// one. The first call primes the baseline and yields `None`.
+    async fn cpu_snapshot(&self) -> Option<CpuPercentages> {
+        let contents = tokio::fs::read_to_string("/proc/stat").await.ok()?;
+        let current = parse_proc_stat(&contents)?;
+        let mut last = self.last_cpu.lock().await;
+        let result = last
+            .as_ref()
+            .and_then(|prev| cpu_percentages(prev, &current));
+        *last = Some(current);
+        result
+    }
+
+    /// Insert one `Server_Stats` row and trim the table to a day.
+    async fn sample_server_load(&self) -> Result<(), DbErr> {
+        let cpu = self.cpu_snapshot().await;
+        let Some(cpu) = cpu else {
+            debug!("no CPU delta yet (first pass, or /proc/stat unreadable)");
+            return Ok(());
+        };
+
+        let backend = self.db.get_database_backend();
+        self.db
+            .execute(Statement::from_sql_and_values(
+                backend,
+                "INSERT INTO Server_Stats \
+                 (ServerId, TimeStamp, CpuUserPercent, CpuNicePercent, \
+                  CpuSystemPercent, CpuIdlePercent, CpuUsagePercent) \
+                 VALUES (?, NOW(), ?, ?, ?, ?, ?)",
+                [
+                    server_id().into(),
+                    cpu.user.into(),
+                    cpu.nice.into(),
+                    cpu.system.into(),
+                    cpu.idle.into(),
+                    cpu.usage.into(),
+                ],
+            ))
+            .await?;
+
+        if let Err(e) = self.update_server_row(&cpu).await {
+            warn!("server row update failed: {e}");
+        }
+
+        // Bounded per pass so a backlog drains gradually instead of locking the
+        // table; the next tick continues.
+        self.db
+            .execute(Statement::from_string(
+                backend,
+                "DELETE FROM Server_Stats WHERE TimeStamp < NOW() - INTERVAL 1 DAY LIMIT 500",
+            ))
+            .await?;
+        Ok(())
+    }
+
+    /// Drop `Monitor_Status` rows that have stopped being updated.
+    ///
+    /// The row is a live heartbeat written by the capture daemon; once it stops
+    /// the values are stale and misleading, so absence is more honest than a
+    /// frozen FPS reading.
+    async fn evict_stale_monitor_status(&self) -> Result<(), DbErr> {
+        let backend = self.db.get_database_backend();
+        let result = self
+            .db
+            .execute(Statement::from_string(
+                backend,
+                "DELETE FROM Monitor_Status \
+                 WHERE UpdatedOn < DATE_SUB(NOW(), INTERVAL 1 MINUTE)",
+            ))
+            .await?;
+        if result.rows_affected() > 0 {
+            debug!(
+                "evicted {} stale monitor status rows",
+                result.rows_affected()
+            );
+        }
+        Ok(())
+    }
+
+    /// Age events out of the four rolling windows, then recompute the counters
+    /// for every monitor whose window changed.
+    ///
+    /// Rows are only ever *removed* here: ZoneMinder's `Events` triggers insert
+    /// them. Deleting from a window fires that window's trigger, which
+    /// decrements `Event_Summaries` — the explicit recount afterwards corrects
+    /// any drift the triggers have accumulated.
+    async fn age_out_event_windows(&self) -> Result<(), DbErr> {
+        const WINDOWS: &[(&str, &str)] = &[
+            ("Events_Hour", "1 HOUR"),
+            ("Events_Day", "1 DAY"),
+            ("Events_Week", "1 WEEK"),
+            ("Events_Month", "1 MONTH"),
+        ];
+
+        let backend = self.db.get_database_backend();
+        let mut any_pruned = false;
+
+        for (table, interval) in WINDOWS {
+            // Chunked: a long-stopped instance can have a very large backlog,
+            // and one unbounded DELETE would hold locks across all of it.
+            loop {
+                let sql = format!(
+                    "DELETE FROM {table} \
+                     WHERE StartDateTime < DATE_SUB(NOW(), INTERVAL {interval}) LIMIT 1000"
+                );
+                let removed = self
+                    .db
+                    .execute(Statement::from_string(backend, sql))
+                    .await?
+                    .rows_affected();
+                if removed > 0 {
+                    any_pruned = true;
+                    debug!("aged {removed} rows out of {table}");
+                }
+                if removed < 1000 {
+                    break;
+                }
+            }
+        }
+
+        if any_pruned {
+            self.resync_window_counters().await?;
+        }
+        Ok(())
+    }
+
+    /// Recompute the Hour/Day/Week/Month counters from the window tables.
+    ///
+    /// Deliberately does not touch `TotalEvents`, `TotalEventDiskSpace`,
+    /// `ArchivedEvents` or `ArchivedEventDiskSpace` — those are derived from
+    /// `Events` rather than from a window, and belong to the audit's full
+    /// resync. Writing them from here would need a scan of the whole `Events`
+    /// table on a timer measured in minutes.
+    async fn resync_window_counters(&self) -> Result<(), DbErr> {
+        let backend = self.db.get_database_backend();
+        // Single-table UPDATE driven by correlated subqueries: a multi-table
+        // UPDATE would take shared locks on the joined rows and hold them to
+        // commit, deadlocking against the Events triggers.
+        self.db
+            .execute(Statement::from_string(
+                backend,
+                "UPDATE Event_Summaries SET \
+                 HourEvents = (SELECT COUNT(*) FROM Events_Hour \
+                     WHERE Events_Hour.MonitorId = Event_Summaries.MonitorId), \
+                 HourEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events_Hour \
+                     WHERE Events_Hour.MonitorId = Event_Summaries.MonitorId), \
+                 DayEvents = (SELECT COUNT(*) FROM Events_Day \
+                     WHERE Events_Day.MonitorId = Event_Summaries.MonitorId), \
+                 DayEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events_Day \
+                     WHERE Events_Day.MonitorId = Event_Summaries.MonitorId), \
+                 WeekEvents = (SELECT COUNT(*) FROM Events_Week \
+                     WHERE Events_Week.MonitorId = Event_Summaries.MonitorId), \
+                 WeekEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events_Week \
+                     WHERE Events_Week.MonitorId = Event_Summaries.MonitorId), \
+                 MonthEvents = (SELECT COUNT(*) FROM Events_Month \
+                     WHERE Events_Month.MonitorId = Event_Summaries.MonitorId), \
+                 MonthEventDiskSpace = (SELECT COALESCE(SUM(DiskSpace),0) FROM Events_Month \
+                     WHERE Events_Month.MonitorId = Event_Summaries.MonitorId)",
+            ))
+            .await?;
+        Ok(())
+    }
+
+    /// Mirror the current load onto this host's own `Servers` row.
+    ///
+    /// Only meaningful on a multi-server install, where `ZM_SERVER_ID`
+    /// identifies which row is ours; a single-server install has no row to
+    /// update and this is skipped.
+    async fn update_server_row(&self, cpu: &CpuPercentages) -> Result<(), DbErr> {
+        let id = server_id();
+        if id == 0 {
+            return Ok(());
+        }
+        self.db
+            .execute(Statement::from_sql_and_values(
+                self.db.get_database_backend(),
+                "UPDATE Servers SET CpuUserPercent = ?, CpuNicePercent = ?, \
+                 CpuSystemPercent = ?, CpuIdlePercent = ?, CpuUsagePercent = ? \
+                 WHERE Id = ?",
+                [
+                    cpu.user.into(),
+                    cpu.nice.into(),
+                    cpu.system.into(),
+                    cpu.idle.into(),
+                    cpu.usage.into(),
+                    id.into(),
+                ],
+            ))
+            .await?;
+        Ok(())
+    }
+
+    /// Prune the `Logs` table under its two independent retentions.
+    ///
+    /// AUDIT rows are kept far longer than ordinary ones (a year against a
+    /// week by default), so each is pruned against its own limit rather than
+    /// one policy for the table.
+    async fn prune_logs(&self) -> Result<(), DbErr> {
+        for (setting, fallback, level_predicate) in [
+            (
+                "ZM_LOG_DATABASE_LIMIT",
+                "7 day",
+                format!("Level != {AUDIT_LEVEL}"),
+            ),
+            (
+                "ZM_LOG_AUDIT_DATABASE_LIMIT",
+                "1 year",
+                format!("Level = {AUDIT_LEVEL}"),
+            ),
+        ] {
+            let raw = read_zm_config_string(self.db.as_ref(), setting)
+                .await
+                .unwrap_or_else(|| fallback.to_string());
+            let Some(limit) = parse_log_limit(&raw) else {
+                // An empty value disables pruning in ZoneMinder; anything else
+                // unparseable is a misconfiguration worth surfacing rather than
+                // guessing around.
+                if !raw.trim().is_empty() {
+                    warn!("{setting} = {raw:?} is not a row count or interval; not pruning");
+                }
+                continue;
+            };
+            self.prune_logs_to(&level_predicate, &limit).await?;
+        }
+        Ok(())
+    }
+
+    async fn prune_logs_to(&self, level_predicate: &str, limit: &LogLimit) -> Result<(), DbErr> {
+        let backend = self.db.get_database_backend();
+        match limit {
+            LogLimit::Age { amount, unit } => loop {
+                // `amount` is a parsed u64 and `unit` comes from an allow-list,
+                // so neither can carry syntax.
+                let sql = format!(
+                    "DELETE LOW_PRIORITY FROM Logs WHERE {level_predicate} \
+                     AND TimeKey < UNIX_TIMESTAMP(NOW() - INTERVAL {amount} {unit}) LIMIT 500"
+                );
+                let removed = self
+                    .db
+                    .execute(Statement::from_string(backend, sql))
+                    .await?
+                    .rows_affected();
+                if removed > 0 {
+                    debug!("pruned {removed} log rows ({level_predicate})");
+                }
+                if removed < 500 {
+                    break;
+                }
+            },
+            LogLimit::Rows(keep) => {
+                use sea_orm::FromQueryResult;
+                #[derive(FromQueryResult)]
+                struct CountRow {
+                    n: i64,
+                }
+                let total = CountRow::find_by_statement(Statement::from_string(
+                    backend,
+                    format!("SELECT COUNT(*) AS n FROM Logs WHERE {level_predicate}"),
+                ))
+                .one(self.db.as_ref())
+                .await?
+                .map(|r| r.n.max(0) as u64)
+                .unwrap_or(0);
+
+                if total > *keep {
+                    let excess = total - keep;
+                    let sql = format!(
+                        "DELETE LOW_PRIORITY FROM Logs WHERE {level_predicate} \
+                         ORDER BY TimeKey ASC LIMIT {excess}"
+                    );
+                    let removed = self
+                        .db
+                        .execute(Statement::from_string(backend, sql))
+                        .await?
+                        .rows_affected();
+                    debug!("pruned {removed} log rows over the {keep}-row limit");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete sessions whose last access is older than the cookie lifetime.
+    ///
+    /// These are the PHP web UI's sessions, which nothing else expires.
+    async fn prune_sessions(&self) -> Result<(), DbErr> {
+        let lifetime = self.cookie_lifetime_secs().await;
+        let cutoff = (chrono::Utc::now().timestamp() as u64).saturating_sub(lifetime);
+        let backend = self.db.get_database_backend();
+        loop {
+            let removed = self
+                .db
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    "DELETE FROM Sessions WHERE access < ? LIMIT 500",
+                    [cutoff.into()],
+                ))
+                .await?
+                .rows_affected();
+            if removed > 0 {
+                debug!("pruned {removed} expired sessions");
+            }
+            if removed < 500 {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// `ZM_COOKIE_LIFETIME`, defaulting to ZoneMinder's own 3600 seconds.
+    async fn cookie_lifetime_secs(&self) -> u64 {
+        read_zm_config_u64(self.db.as_ref(), "ZM_COOKIE_LIFETIME")
+            .await
+            .unwrap_or(3600)
+    }
+}
+
+/// This host's `Servers.Id`, or 0 on a single-server install — matching what
+/// ZoneMinder writes.
+fn server_id() -> u32 {
+    std::env::var("ZM_SERVER_ID")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Read a raw string out of ZoneMinder's `Config` table.
+pub(crate) async fn read_zm_config_string(db: &DatabaseConnection, name: &str) -> Option<String> {
+    use sea_orm::FromQueryResult;
+
+    #[derive(FromQueryResult)]
+    struct Row {
+        value: String,
+    }
+
+    Row::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "SELECT Value AS value FROM Config WHERE Name = ?",
+        [name.into()],
+    ))
+    .one(db)
+    .await
+    .ok()?
+    .map(|r| r.value)
+}
+
+/// Read an integer out of ZoneMinder's `Config` table.
+pub(crate) async fn read_zm_config_u64(db: &DatabaseConnection, name: &str) -> Option<u64> {
+    use sea_orm::FromQueryResult;
+
+    #[derive(FromQueryResult)]
+    struct Row {
+        value: String,
+    }
+
+    let row = Row::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "SELECT Value AS value FROM Config WHERE Name = ?",
+        [name.into()],
+    ))
+    .one(db)
+    .await
+    .ok()??;
+    row.value.trim().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+cpu  100 20 30 800 5 0 5 0 0 0
+cpu0 50 10 15 400 2 0 2 0 0 0
+intr 12345
+";
+
+    #[test]
+    fn parses_the_aggregate_cpu_line() {
+        let s = parse_proc_stat(SAMPLE).expect("parse");
+        assert_eq!(s.user, 100);
+        assert_eq!(s.nice, 20);
+        assert_eq!(s.system, 30);
+        assert_eq!(s.idle, 800);
+        // iowait + irq + softirq + steal + guest + guest_nice, whatever the
+        // kernel offers, so the total stays correct as columns are added.
+        assert_eq!(s.other, 10);
+        assert_eq!(s.total(), 960);
+    }
+
+    #[test]
+    fn ignores_per_core_lines() {
+        // "cpu0" must not be mistaken for "cpu".
+        let only_cores = "cpu0 1 1 1 1\nintr 5\n";
+        assert!(parse_proc_stat(only_cores).is_none());
+    }
+
+    #[test]
+    fn rejects_a_truncated_line() {
+        assert!(parse_proc_stat("cpu 1 2\n").is_none());
+    }
+
+    #[test]
+    fn percentages_are_computed_over_the_delta() {
+        let before = CpuSample {
+            user: 100,
+            nice: 0,
+            system: 100,
+            idle: 800,
+            other: 0,
+        };
+        let after = CpuSample {
+            user: 200,
+            nice: 0,
+            system: 100,
+            idle: 1700,
+            other: 0,
+        };
+        // 100 user + 900 idle = 1000 jiffies elapsed.
+        let pct = cpu_percentages(&before, &after).expect("delta");
+        assert!((pct.user - 10.0).abs() < 1e-9, "{pct:?}");
+        assert!((pct.idle - 90.0).abs() < 1e-9, "{pct:?}");
+        assert!((pct.usage - 10.0).abs() < 1e-9, "{pct:?}");
+        assert!((pct.system - 0.0).abs() < 1e-9, "{pct:?}");
+    }
+
+    #[test]
+    fn an_unchanged_counter_yields_no_percentages() {
+        // Two samples inside one tick must not divide by zero.
+        let s = CpuSample {
+            user: 1,
+            nice: 1,
+            system: 1,
+            idle: 1,
+            other: 0,
+        };
+        assert!(cpu_percentages(&s, &s).is_none());
+    }
+
+    #[test]
+    fn a_counter_reset_does_not_panic() {
+        // /proc/stat counters are monotonic in practice, but a container
+        // restart or a suspended VM can appear to rewind them.
+        let before = CpuSample {
+            user: 500,
+            nice: 0,
+            system: 0,
+            idle: 500,
+            other: 0,
+        };
+        let after = CpuSample {
+            user: 1,
+            nice: 0,
+            system: 0,
+            idle: 1,
+            other: 0,
+        };
+        assert!(cpu_percentages(&before, &after).is_none());
+    }
+
+    #[test]
+    fn a_bare_number_is_a_row_count() {
+        assert_eq!(parse_log_limit("10000"), Some(LogLimit::Rows(10000)));
+    }
+
+    #[test]
+    fn zoneminder_interval_strings_parse() {
+        assert_eq!(
+            parse_log_limit("7 day"),
+            Some(LogLimit::Age {
+                amount: 7,
+                unit: "DAY".into()
+            })
+        );
+        assert_eq!(
+            parse_log_limit("1 year"),
+            Some(LogLimit::Age {
+                amount: 1,
+                unit: "YEAR".into()
+            })
+        );
+        // ZoneMinder writes both "7 day" and "7 days".
+        assert_eq!(
+            parse_log_limit("30 days"),
+            Some(LogLimit::Age {
+                amount: 30,
+                unit: "DAY".into()
+            })
+        );
+    }
+
+    /// The whole reason this is parsed rather than interpolated: ZoneMinder
+    /// splices `ZM_LOG_DATABASE_LIMIT` straight into its DELETE, so a `Config`
+    /// row is SQL. Nothing that is not a plain count or an allow-listed
+    /// interval may get through.
+    #[test]
+    fn hostile_or_malformed_limits_are_rejected() {
+        for hostile in [
+            "1 day; DROP TABLE Logs",
+            "1 DAY) OR 1=1 -- ",
+            "7 fortnight",
+            "day",
+            "7", // handled by the count branch, not here
+            "",
+            "   ",
+            "0",
+            "0 day",
+            "-1 day",
+            "1 day 2 hour",
+            "1;day",
+        ] {
+            let parsed = parse_log_limit(hostile);
+            let acceptable = matches!(parsed, None | Some(LogLimit::Rows(_)));
+            assert!(acceptable, "{hostile:?} parsed as an interval: {parsed:?}");
+            if let Some(LogLimit::Age { ref unit, .. }) = parsed {
+                assert!(
+                    INTERVAL_UNITS.contains(&unit.as_str()),
+                    "{unit} escaped the allow-list"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_accepted_unit_is_on_the_allow_list() {
+        for unit in INTERVAL_UNITS {
+            let raw = format!("2 {}", unit.to_lowercase());
+            match parse_log_limit(&raw) {
+                Some(LogLimit::Age { amount, unit: u }) => {
+                    assert_eq!(amount, 2);
+                    assert_eq!(&u, unit);
+                }
+                other => panic!("{raw:?} should parse as an interval, got {other:?}"),
+            }
+        }
+    }
+}

--- a/src/service/maintenance/telemetry.rs
+++ b/src/service/maintenance/telemetry.rs
@@ -1,0 +1,494 @@
+//! Native replacement for `zmtelemetry.pl`.
+//!
+//! Posts an anonymous usage report on a long interval. Off unless explicitly
+//! enabled, and it stays off — a phone-home that switches itself on is a poor
+//! default however little it sends.
+//!
+//! ## What this deliberately does not do
+//!
+//! **No geolocation lookup.** `zmtelemetry.pl` calls `ipinfo.io` (falling back
+//! to `ip2location.io`) on *every* collection, including under `--show`, and
+//! puts city, region, country and latitude/longitude in the report. That is an
+//! unconditional disclosure of the server's public IP to a third party, done by
+//! something described as anonymous statistics, and it happens even when the
+//! operator only asked to preview the payload. The fields are still sent so the
+//! receiving end sees the shape it expects, but they are always `"Unknown"` —
+//! the same value the Perl uses when both lookups fail.
+//!
+//! **No `eval` of the interval.** `ZM_TELEMETRY_INTERVAL` defaults to the
+//! string `'14*24*60*60'` and the Perl evaluates it as code, which makes a
+//! database row an arbitrary-code-execution surface. Here it is parsed as a
+//! number, and a simple `a*b*c` product is accepted so existing config still
+//! works.
+//!
+//! **Last-upload is compared with `>=`.** The Perl resets its in-memory
+//! `$lastCheck` every iteration and compares with strict `>`, so in steady
+//! state the difference equals the interval exactly and the send is skipped;
+//! reports only reliably go out after a restart.
+
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, FromQueryResult, Statement};
+use serde::Serialize;
+use tracing::{debug, info, warn};
+
+use crate::configure::maintenance::TelemetryConfig;
+
+/// The value the Perl sends when its geolocation lookups fail. Reused so the
+/// receiver sees a shape it already handles.
+const UNKNOWN: &str = "Unknown";
+
+pub struct TelemetryService {
+    db: Arc<DatabaseConnection>,
+    config: TelemetryConfig,
+    http: reqwest::Client,
+}
+
+/// The reported payload. Field names match `zmtelemetry.pl` exactly, so the
+/// receiving end needs no changes.
+#[derive(Debug, Serialize, PartialEq)]
+pub struct TelemetryReport {
+    pub uuid: String,
+    pub timezone: String,
+    pub city: String,
+    pub region: String,
+    pub country: String,
+    pub latitude: String,
+    pub longitude: String,
+    pub timestamp: String,
+    pub monitor_count: i64,
+    pub event_count: i64,
+    pub architecture: String,
+    pub kernel: String,
+    pub distro: String,
+    pub version: String,
+    pub zm_version: String,
+    pub system_memory: u64,
+    pub processor_count: usize,
+    pub use_event_server: bool,
+    pub monitors: Vec<MonitorReport>,
+}
+
+/// Per-monitor detail. `path` is scrubbed before it leaves the machine.
+#[derive(Debug, Serialize, PartialEq, FromQueryResult)]
+pub struct MonitorReport {
+    pub id: u32,
+    pub name: String,
+    pub r#type: String,
+    pub width: u32,
+    pub height: u32,
+    pub colours: u8,
+    pub path: String,
+}
+
+/// Strip credentials *and* host from a camera URL, keeping only the shape.
+///
+/// The Perl replaces the whole authority with the literal
+/// `username:password@host`, so the hostname does not leave the machine either.
+/// A value that is not a URL — a local device path — is replaced outright
+/// rather than passed through, since `/dev/video0` is harmless but a UNC path
+/// or a file path containing a hostname is not.
+pub fn scrub_monitor_path(path: &str, is_local: bool) -> String {
+    if is_local {
+        return path.to_string();
+    }
+    match url::Url::parse(path) {
+        Ok(mut url) => {
+            // Keep scheme and path shape; discard credentials and host.
+            let _ = url.set_username("username");
+            let _ = url.set_password(Some("password"));
+            let _ = url.set_host(Some("host"));
+            url.to_string()
+        }
+        Err(_) => UNKNOWN.to_string(),
+    }
+}
+
+/// Parse `ZM_TELEMETRY_INTERVAL`, which ships as the Perl expression
+/// `14*24*60*60`.
+///
+/// Accepts a plain integer or a product of integers. Anything else returns
+/// `None` and the caller falls back to its configured default — the Perl would
+/// `eval` it, which turns a database row into code execution.
+pub fn parse_interval_expression(raw: &str) -> Option<u64> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let mut product: u64 = 1;
+    for factor in raw.split('*') {
+        let n: u64 = factor.trim().parse().ok()?;
+        product = product.checked_mul(n)?;
+    }
+    (product > 0).then_some(product)
+}
+
+impl TelemetryService {
+    pub fn new(
+        db: Arc<DatabaseConnection>,
+        config: TelemetryConfig,
+        http: reqwest::Client,
+    ) -> Self {
+        Self { db, config, http }
+    }
+
+    pub fn spawn(self: Arc<Self>) {
+        let interval = self.config.interval();
+        tokio::spawn(async move {
+            // Check often; the decision to send is made against the persisted
+            // last-upload timestamp, not against how long this process has been
+            // up. A daily restart would otherwise never reach a 14-day timer.
+            let tick = interval.min(std::time::Duration::from_secs(3600));
+            let mut ticker = tokio::time::interval(tick);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                if let Err(e) = self.send_if_due().await {
+                    warn!("telemetry pass failed: {e}");
+                }
+            }
+        });
+    }
+
+    /// Send a report if the configured interval has elapsed since the last
+    /// successful upload.
+    pub async fn send_if_due(&self) -> Result<bool, DbErr> {
+        let interval = self.effective_interval().await;
+        let last = self.last_upload().await.unwrap_or(0);
+        let now = chrono::Utc::now().timestamp();
+
+        // `>=` rather than `>`: with a timer that fires exactly on the
+        // interval, strict greater-than skips almost every send.
+        if last != 0 && now.saturating_sub(last) < interval as i64 {
+            debug!(
+                "telemetry not due for another {}s",
+                interval as i64 - (now - last)
+            );
+            return Ok(false);
+        }
+
+        let report = self.collect().await?;
+        match self.post(&report).await {
+            Ok(()) => {
+                self.record_upload(now).await?;
+                info!("telemetry report sent to {}", self.config.endpoint);
+                Ok(true)
+            }
+            Err(e) => {
+                // Deliberately does not record the timestamp: a failed send
+                // should be retried, not silently counted as done.
+                warn!("telemetry upload failed: {e}");
+                Ok(false)
+            }
+        }
+    }
+
+    /// Assemble the report. Public so `--show`-style previewing can print it
+    /// without sending anything.
+    pub async fn collect(&self) -> Result<TelemetryReport, DbErr> {
+        let backend = self.db.get_database_backend();
+
+        #[derive(FromQueryResult)]
+        struct Count {
+            n: i64,
+        }
+        let count = |sql: &'static str| async move {
+            Count::find_by_statement(Statement::from_string(backend, sql))
+                .one(self.db.as_ref())
+                .await
+                .ok()
+                .flatten()
+                .map(|r| r.n)
+                .unwrap_or(0)
+        };
+
+        let monitor_count = count("SELECT COUNT(*) AS n FROM Monitors WHERE Deleted = 0").await;
+        let event_count = count("SELECT COUNT(*) AS n FROM Events").await;
+
+        #[derive(FromQueryResult)]
+        struct MonitorRow {
+            id: u32,
+            name: String,
+            r#type: String,
+            width: u32,
+            height: u32,
+            colours: u8,
+            path: Option<String>,
+        }
+
+        let monitors = MonitorRow::find_by_statement(Statement::from_string(
+            backend,
+            "SELECT Id AS id, Name AS name, Type AS type, Width AS width, \
+                    Height AS height, Colours AS colours, Path AS path \
+             FROM Monitors WHERE Deleted = 0",
+        ))
+        .all(self.db.as_ref())
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|m| {
+            let is_local = m.r#type.eq_ignore_ascii_case("local");
+            MonitorReport {
+                path: scrub_monitor_path(m.path.as_deref().unwrap_or(""), is_local),
+                id: m.id,
+                name: m.name,
+                r#type: m.r#type,
+                width: m.width,
+                height: m.height,
+                colours: m.colours,
+            }
+        })
+        .collect();
+
+        Ok(TelemetryReport {
+            uuid: self.uuid().await,
+            timezone: iana_time_zone::get_timezone().unwrap_or_else(|_| UNKNOWN.to_string()),
+            // Never looked up — see the module note.
+            city: UNKNOWN.to_string(),
+            region: UNKNOWN.to_string(),
+            country: UNKNOWN.to_string(),
+            latitude: UNKNOWN.to_string(),
+            longitude: UNKNOWN.to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            monitor_count,
+            event_count,
+            architecture: std::env::consts::ARCH.to_string(),
+            kernel: std::env::consts::OS.to_string(),
+            distro: read_os_release_field("NAME").unwrap_or_else(|| UNKNOWN.to_string()),
+            version: read_os_release_field("VERSION_ID").unwrap_or_else(|| UNKNOWN.to_string()),
+            zm_version: env!("CARGO_PKG_VERSION").to_string(),
+            system_memory: total_memory_bytes(),
+            processor_count: std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(0),
+            use_event_server: false,
+            monitors,
+        })
+    }
+
+    async fn post(&self, report: &TelemetryReport) -> Result<(), reqwest::Error> {
+        // Sent as JSON with a truthful content type. The Perl declares
+        // `application/x-www-form-urlencoded` while sending a JSON body.
+        self.http
+            .post(&self.config.endpoint)
+            .json(report)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    async fn effective_interval(&self) -> u64 {
+        match read_zm_config_str(self.db.as_ref(), "ZM_TELEMETRY_INTERVAL").await {
+            Some(raw) => parse_interval_expression(&raw).unwrap_or_else(|| {
+                warn!("ZM_TELEMETRY_INTERVAL {raw:?} is not a number or product; using config");
+                self.config.interval_seconds
+            }),
+            None => self.config.interval_seconds,
+        }
+    }
+
+    async fn last_upload(&self) -> Option<i64> {
+        read_zm_config_str(self.db.as_ref(), "ZM_TELEMETRY_LAST_UPLOAD")
+            .await?
+            .trim()
+            .parse()
+            .ok()
+    }
+
+    /// This install's stable anonymous identifier, minted on first use.
+    async fn uuid(&self) -> String {
+        if let Some(existing) = read_zm_config_str(self.db.as_ref(), "ZM_TELEMETRY_UUID").await {
+            if !existing.trim().is_empty() {
+                return existing;
+            }
+        }
+        let fresh = uuid::Uuid::new_v4().to_string();
+        if let Err(e) = self.write_config("ZM_TELEMETRY_UUID", &fresh).await {
+            warn!("could not persist telemetry uuid: {e}");
+        }
+        fresh
+    }
+
+    async fn record_upload(&self, at: i64) -> Result<(), DbErr> {
+        self.write_config("ZM_TELEMETRY_LAST_UPLOAD", &at.to_string())
+            .await
+    }
+
+    async fn write_config(&self, name: &str, value: &str) -> Result<(), DbErr> {
+        self.db
+            .execute(Statement::from_sql_and_values(
+                self.db.get_database_backend(),
+                "UPDATE Config SET Value = ? WHERE Name = ?",
+                [value.into(), name.into()],
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+async fn read_zm_config_str(db: &DatabaseConnection, name: &str) -> Option<String> {
+    #[derive(FromQueryResult)]
+    struct Row {
+        value: String,
+    }
+    Row::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "SELECT Value AS value FROM Config WHERE Name = ?",
+        [name.into()],
+    ))
+    .one(db)
+    .await
+    .ok()?
+    .map(|r| r.value)
+}
+
+/// A field from `/etc/os-release`, unquoted.
+fn read_os_release_field(key: &str) -> Option<String> {
+    let contents = std::fs::read_to_string("/etc/os-release").ok()?;
+    parse_os_release_field(&contents, key)
+}
+
+pub fn parse_os_release_field(contents: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    contents.lines().find_map(|line| {
+        line.strip_prefix(&prefix)
+            .map(|v| v.trim().trim_matches('"').to_string())
+    })
+}
+
+/// Total system memory in bytes, or 0 if it cannot be determined.
+fn total_memory_bytes() -> u64 {
+    std::fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|c| parse_meminfo_total(&c))
+        .unwrap_or(0)
+}
+
+pub fn parse_meminfo_total(contents: &str) -> Option<u64> {
+    let line = contents.lines().find(|l| l.starts_with("MemTotal:"))?;
+    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kb * 1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_and_host_are_stripped_from_camera_urls() {
+        let scrubbed = scrub_monitor_path("rtsp://admin:hunter2@10.0.0.5:554/stream1", false);
+        assert!(!scrubbed.contains("admin"), "{scrubbed}");
+        assert!(!scrubbed.contains("hunter2"), "{scrubbed}");
+        assert!(!scrubbed.contains("10.0.0.5"), "{scrubbed}");
+        // The shape is still recognisable, which is the point of sending it.
+        assert!(scrubbed.starts_with("rtsp://"), "{scrubbed}");
+        assert!(scrubbed.ends_with("/stream1"), "{scrubbed}");
+    }
+
+    #[test]
+    fn a_local_device_path_is_left_alone() {
+        assert_eq!(scrub_monitor_path("/dev/video0", true), "/dev/video0");
+    }
+
+    #[test]
+    fn an_unparseable_remote_path_is_discarded_not_forwarded() {
+        // Better to send nothing than to leak a hostname from something that
+        // only looked like a device path.
+        assert_eq!(
+            scrub_monitor_path("\\\\fileserver\\share\\cam", false),
+            UNKNOWN
+        );
+    }
+
+    #[test]
+    fn the_perl_interval_expression_is_parsed_not_evaluated() {
+        assert_eq!(parse_interval_expression("14*24*60*60"), Some(1_209_600));
+        assert_eq!(parse_interval_expression("3600"), Some(3600));
+        assert_eq!(parse_interval_expression(" 2 * 3 "), Some(6));
+    }
+
+    #[test]
+    fn a_non_arithmetic_interval_is_rejected_rather_than_run() {
+        // The Perl `eval`s this string, so a Config row is code. These must all
+        // fall back to the configured default instead.
+        for hostile in [
+            "system('rm -rf /')",
+            "`id`",
+            "$x",
+            "",
+            "14*",
+            "0",
+            "-1",
+            "1e9",
+        ] {
+            assert_eq!(
+                parse_interval_expression(hostile),
+                None,
+                "{hostile:?} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn interval_overflow_does_not_wrap() {
+        assert_eq!(
+            parse_interval_expression("99999999999*99999999999*99999999999"),
+            None
+        );
+    }
+
+    #[test]
+    fn os_release_values_are_unquoted() {
+        let sample = "NAME=\"Ubuntu\"\nVERSION_ID=\"24.04\"\nID=ubuntu\n";
+        assert_eq!(
+            parse_os_release_field(sample, "NAME"),
+            Some("Ubuntu".to_string())
+        );
+        assert_eq!(
+            parse_os_release_field(sample, "VERSION_ID"),
+            Some("24.04".to_string())
+        );
+        assert_eq!(parse_os_release_field(sample, "MISSING"), None);
+    }
+
+    #[test]
+    fn meminfo_is_reported_in_bytes() {
+        let sample = "MemTotal:       16316412 kB\nMemFree:         123 kB\n";
+        assert_eq!(parse_meminfo_total(sample), Some(16_316_412 * 1024));
+    }
+
+    #[test]
+    fn the_report_carries_no_geolocation() {
+        // Guards the deliberate departure: these must stay literal, never
+        // populated from a third-party lookup.
+        let report = TelemetryReport {
+            uuid: "u".into(),
+            timezone: "UTC".into(),
+            city: UNKNOWN.into(),
+            region: UNKNOWN.into(),
+            country: UNKNOWN.into(),
+            latitude: UNKNOWN.into(),
+            longitude: UNKNOWN.into(),
+            timestamp: "t".into(),
+            monitor_count: 0,
+            event_count: 0,
+            architecture: "x86_64".into(),
+            kernel: "linux".into(),
+            distro: "Ubuntu".into(),
+            version: "24.04".into(),
+            zm_version: "3.0.0".into(),
+            system_memory: 0,
+            processor_count: 1,
+            use_event_server: false,
+            monitors: vec![],
+        };
+        let json = serde_json::to_value(&report).unwrap();
+        for field in ["city", "region", "country", "latitude", "longitude"] {
+            assert_eq!(json[field], UNKNOWN, "{field} must not be looked up");
+        }
+        // The receiver still sees every field it expects.
+        assert!(json.get("monitor_count").is_some());
+        assert!(json.get("zm_version").is_some());
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -24,6 +24,7 @@ pub mod groups_monitors;
 pub mod groups_permissions;
 pub mod image_orientation;
 pub mod logs;
+pub mod maintenance;
 pub mod manufacturers;
 pub mod models;
 pub mod monitor;

--- a/tests/it_maintenance.rs
+++ b/tests/it_maintenance.rs
@@ -1,0 +1,353 @@
+//! Integration tests for the native replacements of `zmaudit.pl` and
+//! `zmstats.pl`, against a real schema.
+//!
+//! The unit tests cover the parsers and the arithmetic; these cover the SQL,
+//! which is where a reimplementation of a destructive daemon actually goes
+//! wrong. Every deleting path is checked twice: that it removes what it should,
+//! and that it leaves alone what it must.
+//!
+//! Requires the test database — run with:
+//!   APP_PROFILE=test-db cargo test --test it_maintenance -- --include-ignored
+
+mod common;
+
+use std::sync::Arc;
+
+use common::test_db::get_test_db;
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
+use zm_api::configure::maintenance::{AuditConfig, StatsConfig};
+use zm_api::service::maintenance::{audit::AuditService, stats::StatsService};
+
+/// Monitor ids well clear of anything a fixture or a real install would use.
+///
+/// One per test, because these run in parallel against a shared database and
+/// each test's cleanup deletes by monitor id — a single shared id has them
+/// deleting each other's fixtures mid-run.
+const MON_EMPTY: u32 = 99_311;
+const MON_FRAMES: u32 = 99_312;
+const MON_UNCLOSED: u32 = 99_313;
+const MON_COUNTERS: u32 = 99_314;
+
+async fn exec(db: &DatabaseConnection, sql: impl Into<String>) {
+    db.execute(Statement::from_string(
+        db.get_database_backend(),
+        sql.into(),
+    ))
+    .await
+    .expect("statement");
+}
+
+async fn scalar(db: &DatabaseConnection, sql: &str) -> i64 {
+    use sea_orm::FromQueryResult;
+    #[derive(FromQueryResult)]
+    struct Row {
+        n: i64,
+    }
+    Row::find_by_statement(Statement::from_string(
+        db.get_database_backend(),
+        sql.to_string(),
+    ))
+    .one(db)
+    .await
+    .expect("query")
+    .map(|r| r.n)
+    .unwrap_or(0)
+}
+
+/// Remove everything this test file creates, so a failed run cannot poison the
+/// next one.
+async fn cleanup(db: &DatabaseConnection, monitor: u32, first_event: u64, last_event: u64) {
+    exec(
+        db,
+        format!("DELETE FROM Frames WHERE EventId BETWEEN {first_event} AND {last_event}"),
+    )
+    .await;
+    exec(
+        db,
+        format!("DELETE FROM Events WHERE MonitorId = {monitor}"),
+    )
+    .await;
+    exec(
+        db,
+        format!("DELETE FROM Event_Summaries WHERE MonitorId = {monitor}"),
+    )
+    .await;
+}
+
+fn audit_config(dry_run: bool) -> AuditConfig {
+    AuditConfig {
+        enabled: true,
+        dry_run,
+        min_age_seconds: 3600,
+        ..AuditConfig::default()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn empty_events_are_deleted_but_only_when_old_and_unarchived() {
+    const MON: u32 = MON_EMPTY;
+    let db = Arc::new(get_test_db().await.expect("test db"));
+    cleanup(&db, MON, 9_930_001, 9_930_004).await;
+
+    // 1: old, no frames, not archived  -> must be deleted
+    // 2: old, no frames, ARCHIVED      -> must survive (zmaudit deletes this;
+    //                                     its Archived guard never fires
+    //                                     because the column is not selected)
+    // 3: recent, no frames             -> must survive (still recording)
+    // 4: old, has a frame              -> must survive
+    for (id, age_secs, archived) in [
+        (9_930_001u64, 7200, 0),
+        (9_930_002, 7200, 1),
+        (9_930_003, 60, 0),
+        (9_930_004, 7200, 0),
+    ] {
+        exec(
+            &db,
+            format!(
+                "INSERT INTO Events (Id, MonitorId, StateId, StartDateTime, Archived, Scheme) \
+                 VALUES ({id}, {MON}, 1, DATE_SUB(NOW(), INTERVAL {age_secs} SECOND), \
+                 {archived}, 'Deep')"
+            ),
+        )
+        .await;
+    }
+    exec(
+        &db,
+        "INSERT INTO Frames (EventId, FrameId, Type, TimeStamp, Delta, Score) \
+         VALUES (9930004, 1, 'Normal', NOW(), 0, 0)",
+    )
+    .await;
+
+    // A dry run must change nothing while still reporting the finding.
+    let dry = AuditService::new(Arc::clone(&db), audit_config(true));
+    let report = dry.run_once().await.expect("dry pass");
+    assert_eq!(report.empty_events, 1, "dry run should find exactly one");
+    assert_eq!(
+        scalar(
+            &db,
+            &format!("SELECT COUNT(*) AS n FROM Events WHERE MonitorId={MON}")
+        )
+        .await,
+        4,
+        "dry run must not delete anything"
+    );
+
+    let live = AuditService::new(Arc::clone(&db), audit_config(false));
+    live.run_once().await.expect("live pass");
+
+    let survivors = scalar(
+        &db,
+        &format!("SELECT COUNT(*) AS n FROM Events WHERE MonitorId={MON}"),
+    )
+    .await;
+    assert_eq!(survivors, 3, "only the old unarchived frameless event goes");
+    assert_eq!(
+        scalar(&db, "SELECT COUNT(*) AS n FROM Events WHERE Id=9930001").await,
+        0
+    );
+    assert_eq!(
+        scalar(&db, "SELECT COUNT(*) AS n FROM Events WHERE Id=9930002").await,
+        1,
+        "an archived event must never be deleted for being empty"
+    );
+    assert_eq!(
+        scalar(&db, "SELECT COUNT(*) AS n FROM Events WHERE Id=9930003").await,
+        1,
+        "an event younger than min_age is still recording"
+    );
+
+    cleanup(&db, MON, 9_930_001, 9_930_004).await;
+}
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn orphaned_frames_are_removed_and_live_ones_kept() {
+    const MON: u32 = MON_FRAMES;
+    let db = Arc::new(get_test_db().await.expect("test db"));
+    cleanup(&db, MON, 9_930_010, 9_930_011).await;
+
+    exec(
+        &db,
+        format!(
+            "INSERT INTO Events (Id, MonitorId, StateId, StartDateTime, Scheme) \
+             VALUES (9930010, {MON}, 1, NOW(), 'Deep')"
+        ),
+    )
+    .await;
+    // One frame on a real event, one pointing at an event that never existed.
+    exec(
+        &db,
+        "INSERT INTO Frames (EventId, FrameId, Type, TimeStamp, Delta, Score) \
+         VALUES (9930010, 1, 'Normal', NOW(), 0, 0), \
+                (9930011, 1, 'Normal', NOW(), 0, 0)",
+    )
+    .await;
+
+    let audit = AuditService::new(Arc::clone(&db), audit_config(false));
+    audit.run_once().await.expect("pass");
+
+    assert_eq!(
+        scalar(
+            &db,
+            "SELECT COUNT(*) AS n FROM Frames WHERE EventId=9930011"
+        )
+        .await,
+        0,
+        "the orphan should be gone"
+    );
+    assert_eq!(
+        scalar(
+            &db,
+            "SELECT COUNT(*) AS n FROM Frames WHERE EventId=9930010"
+        )
+        .await,
+        1,
+        "a frame belonging to a live event must be kept"
+    );
+
+    cleanup(&db, MON, 9_930_010, 9_930_011).await;
+}
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn an_unclosed_event_is_closed_from_its_frames() {
+    const MON: u32 = MON_UNCLOSED;
+    let db = Arc::new(get_test_db().await.expect("test db"));
+    cleanup(&db, MON, 9_930_020, 9_930_020).await;
+
+    exec(
+        &db,
+        format!(
+            "INSERT INTO Events (Id, MonitorId, StateId, StartDateTime, EndDateTime, Scheme, Notes) \
+             VALUES (9930020, {MON}, 1, DATE_SUB(NOW(), INTERVAL 2 HOUR), NULL, 'Deep', '')"
+        ),
+    )
+    .await;
+    exec(
+        &db,
+        "INSERT INTO Frames (EventId, FrameId, Type, TimeStamp, Delta, Score) VALUES \
+         (9930020, 1, 'Normal', DATE_SUB(NOW(), INTERVAL 2 HOUR), 0, 0), \
+         (9930020, 2, 'Alarm',  DATE_SUB(NOW(), INTERVAL 119 MINUTE), 0, 7), \
+         (9930020, 3, 'Alarm',  DATE_SUB(NOW(), INTERVAL 118 MINUTE), 0, 3)",
+    )
+    .await;
+
+    let audit = AuditService::new(Arc::clone(&db), audit_config(false));
+    audit.run_once().await.expect("pass");
+
+    use sea_orm::FromQueryResult;
+    // Column types are the schema's, not conveniently uniform: Frames and
+    // AlarmFrames are INT UNSIGNED, the scores are smaller still. Cast in SQL
+    // so the decode does not depend on remembering each width.
+    #[derive(FromQueryResult)]
+    struct Closed {
+        frames: i64,
+        alarm_frames: i64,
+        tot_score: i64,
+        max_score: i64,
+        still_open: i64,
+        notes: String,
+    }
+    let row = Closed::find_by_statement(Statement::from_string(
+        db.get_database_backend(),
+        "SELECT CAST(Frames AS SIGNED) AS frames, \
+                CAST(AlarmFrames AS SIGNED) AS alarm_frames, \
+                CAST(TotScore AS SIGNED) AS tot_score, \
+                CAST(MaxScore AS SIGNED) AS max_score, \
+                CAST(ISNULL(EndDateTime) AS SIGNED) AS still_open, \
+                Notes AS notes \
+         FROM Events WHERE Id = 9930020"
+            .to_string(),
+    ))
+    .one(db.as_ref())
+    .await
+    .expect("query")
+    .expect("event still present");
+
+    assert_eq!(row.still_open, 0, "EndDateTime should now be set");
+    assert_eq!(row.frames, 3);
+    assert_eq!(row.alarm_frames, 2, "only frames with a score above zero");
+    assert_eq!(row.tot_score, 10);
+    assert_eq!(row.max_score, 7);
+    assert!(
+        row.notes.contains("Recovered."),
+        "the repair should be visible, got {:?}",
+        row.notes
+    );
+
+    cleanup(&db, MON, 9_930_020, 9_930_020).await;
+}
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn counter_resync_corrects_drift() {
+    const MON: u32 = MON_COUNTERS;
+    let db = Arc::new(get_test_db().await.expect("test db"));
+    cleanup(&db, MON, 9_930_030, 9_930_031).await;
+
+    exec(
+        &db,
+        format!(
+            "INSERT INTO Events (Id, MonitorId, StateId, StartDateTime, DiskSpace, Archived, Scheme) \
+             VALUES (9930030, {MON}, 1, NOW(), 1000, 0, 'Deep'), \
+                    (9930031, {MON}, 1, NOW(), 2000, 1, 'Deep')"
+        ),
+    )
+    .await;
+    // Deliberately wrong counters, as a missed trigger would leave them.
+    exec(
+        &db,
+        format!(
+            "REPLACE INTO Event_Summaries \
+             (MonitorId, TotalEvents, TotalEventDiskSpace, ArchivedEvents, ArchivedEventDiskSpace) \
+             VALUES ({MON}, 99, 99999, 99, 99999)"
+        ),
+    )
+    .await;
+
+    let audit = AuditService::new(Arc::clone(&db), audit_config(false));
+    audit.run_once().await.expect("pass");
+
+    let total = scalar(
+        &db,
+        &format!("SELECT TotalEvents AS n FROM Event_Summaries WHERE MonitorId={MON}"),
+    )
+    .await;
+    let disk = scalar(
+        &db,
+        &format!("SELECT TotalEventDiskSpace AS n FROM Event_Summaries WHERE MonitorId={MON}"),
+    )
+    .await;
+    let archived = scalar(
+        &db,
+        &format!("SELECT ArchivedEvents AS n FROM Event_Summaries WHERE MonitorId={MON}"),
+    )
+    .await;
+
+    assert_eq!(total, 2, "TotalEvents should be recomputed from Events");
+    assert_eq!(disk, 3000);
+    assert_eq!(archived, 1);
+
+    cleanup(&db, MON, 9_930_030, 9_930_031).await;
+}
+
+#[tokio::test]
+#[ignore = "requires the test database (APP_PROFILE=test-db)"]
+async fn a_stats_pass_runs_clean_against_a_real_schema() {
+    // Every statement zmstats issues, executed once. This does not assert on
+    // counts — the shared test database has other tests' rows in it — but it
+    // does prove the SQL is valid against the real schema, which is the failure
+    // mode that matters for hand-written statements.
+    let db = Arc::new(get_test_db().await.expect("test db"));
+    let stats = StatsService::new(
+        Arc::clone(&db),
+        StatsConfig {
+            enabled: true,
+            interval_seconds: 300,
+        },
+    );
+    stats.run_once().await.expect("a stats pass must not error");
+    // Twice, so the CPU-delta branch runs with a primed baseline too.
+    stats.run_once().await.expect("second stats pass");
+}


### PR DESCRIPTION
Three of ZoneMinder's Perl maintenance daemons, reimplemented in-process. They were the cheapest to absorb: periodic housekeeping whose only state is the database.

Each is independently switchable under `[maintenance]` and **all default off**, so an existing install keeps running the Perl until you move over. Enabling one without disabling its counterpart has them competing over the same rows — the config comments and the guide both say so.

## Behaviour taken from upstream, not inferred

I read the actual `zmstats.pl.in`, `zmaudit.pl.in` and `zmtelemetry.pl.in` rather than guessing. That mattered: **zmstats does six jobs**, not the rollup maintenance I'd assumed. It also samples CPU/memory into `Server_Stats`, evicts stale `Monitor_Status` heartbeats, and prunes `Logs` and `Sessions`.

## Three deliberate departures — each because the Perl is wrong

**Archived events are genuinely skipped.** zmaudit intends to skip them when deleting frameless events, but its `SELECT` list is `E.Id, E.StartDateTime, F.EventId` — `Archived` is never fetched, the guard is always false, and it deletes them. Archiving an event is a user saying *keep this*. Pinned by an integration test.

**`dry_run` writes nothing.** zmaudit's `--report` suppresses its deletes but still performs row updates, empty-directory removal, stray-image unlinking, log pruning and counter resyncs. "Just report" is not what it does.

**No geolocation lookup.** zmtelemetry calls `ipinfo.io` on *every* collection — including under `--show`, when you only asked to preview the payload — and reports city, region, country and lat/long. That's an unconditional disclosure of the server's public IP to a third party, under the heading of anonymous statistics. The fields are still sent so the receiver sees its expected shape, always `"Unknown"`.

## Injection surfaces closed

Retention limits and the telemetry interval come from ZoneMinder's `Config` table, but are **parsed** rather than interpolated:

- the Perl splices `ZM_LOG_DATABASE_LIMIT` straight into its `DELETE`
- the Perl `eval`s `ZM_TELEMETRY_INTERVAL` as Perl — the default value is literally the string `14*24*60*60`

Here the interval unit comes from an allow-list and the telemetry interval accepts only a number or a product of numbers. Hostile inputs for both are covered by tests (`"1 day; DROP TABLE Logs"`, `"system('rm -rf /')"`, overflow, and so on).

Camera paths in the telemetry report have credentials **and** hostname replaced; a remote path that won't parse as a URL is dropped rather than forwarded, since something that only looked like a device path shouldn't leak a hostname.

## Not included: the filesystem half of zmaudit

Reconciling event *directories* against rows is deliberately out of scope, and the guide says so plainly rather than letting anyone assume it moved over.

That's where zmaudit's real hazard lives: its `rm -rf` target is derived from `StartDateTime` formatted in the process's **local timezone**, so a TZ mismatch between the recording daemon and the auditor aims it at a directory that was never the event's. It wants its own change. `service::event_storage` already centralises the path derivation it will need, and the retention reaper already bounds disk for events the database knows about — the more common need.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` — **916 passed, 0 failed**.

Six DB-gated integration tests run against a real MariaDB schema and check **both directions** of every deleting path — what goes, and what must not:

- an old frameless event is deleted; an archived one, a recent one, and one with frames all survive
- an orphaned `Frames` row goes; one belonging to a live event stays
- an unclosed event is closed with the right frame/alarm/score totals from its frames
- drifted `Event_Summaries` counters are corrected
- a full stats pass runs clean against the real schema (this is the one that validates the hand-written SQL)

Writing those caught two fixture bugs of my own: a missing `NOT NULL` column, and four tests sharing one monitor id so their cleanups deleted each other's rows mid-run.